### PR TITLE
no-recursive, fixes #20

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -65,6 +65,11 @@ const {
     type: 'boolean',
     default: true
   })
+  .options('no-recursive', {
+    describe: 'Do not crawl recursively. Opposite of --recursive option.',
+    type: 'boolean',
+    default: false
+  })
   .options('debug', {
     alias: 'd',
     describe: 'Verbose insights into font glyph detection',


### PR DESCRIPTION
I don't understand `yargs`. It seems it was already possible to do `--no-recursive` and it set `recursive===false`. How odd!

Anyway, this PR adds it to `--help`

``
▶ node lib/cli.js --help
Create optimal font subsets from your actual font usage.
cli.js [options] <htmlFile(s) | url(s)>

Options:
  --help           Show help                                   [boolean]
  --version        Show version number                         [boolean]
  --root           Path to your web root (will be deduced from your
                   input files if not specified)                [string]
  --canonicalroot  URI root where the site will be deployed. Must be
                   either an absolute or a protocol-relative url.
                                                                [string]
  --output, -o     Directory where results should be written to [string]
  --in-place, -i   Modify HTML-files in-place. Only use on build
                   artifacts                  [boolean] [default: false]
  --inline-fonts   Inline fonts as data-URIs inside the @font-face
                   declaration                [boolean] [default: false]
  --inline-css     Inline CSS that declares the @font-face for the
                   subset fonts               [boolean] [default: false]
  --font-display   Injects a font-display value into the @font-face CSS.
                   Valid values: auto, block, swap, fallback, optional
     [string] [choices: "auto", "block", "swap", "fallback", "optional"]
                                                       [default: "swap"]
  --recursive, -r  Crawl all HTML-pages linked with relative and root
                   relative links. This stays inside your domain
                                               [boolean] [default: true]
  --no-recursive   Do not crawl recursively. Opposite of --recursive
                   option.                    [boolean] [default: false]
  --debug, -d      Verbose insights into font glyph detection
                                              [boolean] [default: false]


```