### PR TITLE
Make --no-recursive the default

### DIFF
--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -72,7 +72,7 @@ module.exports = function parseCommandLineOptions(argv) {
       describe:
         'Crawl all HTML-pages linked with relative and root relative links. This stays inside your domain',
       type: 'boolean',
-      default: true
+      default: false
     })
     .options('no-recursive', {
       describe: 'Do not crawl recursively. Opposite of --recursive option.',

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -18,7 +18,7 @@ module.exports = async function subfont(
     fontDisplay = 'swap',
     inPlace = false,
     inputFiles = [],
-    recursive = true,
+    recursive = false,
     fallbacks = true
   },
   console


### PR DESCRIPTION
There's a bit of evidence that `--recursive` is causing confusion and is hard to control:

* [How do you NOT recursive](https://github.com/Munter/subfont/issues/20)
* [Multiple calls to subfont causing errors](https://github.com/Munter/subfont/issues/26)

We've previously talked about defaulting to non-recursive mode when we do the next major release. I'm leaving this here so we remember :)