### PR TITLE
Output a bit of size stats per page

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,7 @@
 
 const yargs = require('yargs');
 const subfont = require('./subfont');
+const prettyBytes = require('pretty-bytes');
 const {
   root,
   canonicalroot,
@@ -142,6 +143,22 @@ if (!inPlace && !outRoot) {
 
     if (debug) {
       console.log(require('util').inspect(fontInfo, false, 99));
+    }
+
+    for (const { htmlAsset, fontUsages } of fontInfo) {
+      let sumSmallestSubsetSize = 0;
+      let sumSmallestOriginalSize = 0;
+      for (const fontUsage of fontUsages) {
+        sumSmallestSubsetSize += fontUsage.smallestSubsetSize;
+        sumSmallestOriginalSize += fontUsage.smallestOriginalSize;
+      }
+      console.log(
+        `${htmlAsset}: ${
+          fontUsages.length
+        } font variant(s) in use, ${prettyBytes(
+          sumSmallestOriginalSize
+        )} total. Created subsets: ${prettyBytes(sumSmallestSubsetSize)} total`
+      );
     }
     console.log('Output written to', outRoot || assetGraph.root);
   } catch (err) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -191,7 +191,9 @@ if (!inPlace && !outRoot) {
               String(maxOriginalCodePoints).length
             )} codepoints used, ${prettyBytes(
               fontUsage.smallestOriginalSize
-            )} => ${prettyBytes(fontUsage.smallestSubsetSize)}`
+            )} (${fontUsage.smallestOriginalFormat}) => ${prettyBytes(
+              fontUsage.smallestSubsetSize
+            )} (${fontUsage.smallestSubsetFormat})`
           );
           totalSavings +=
             fontUsage.smallestOriginalSize - fontUsage.smallestSubsetSize;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 const yargs = require('yargs');
 const subfont = require('./subfont');
 const prettyBytes = require('pretty-bytes');
+const groupBy = require('lodash.groupby');
 const {
   root,
   canonicalroot,
@@ -145,21 +146,59 @@ if (!inPlace && !outRoot) {
       console.log(require('util').inspect(fontInfo, false, 99));
     }
 
+    let totalSavings = 0;
     for (const { htmlAsset, fontUsages } of fontInfo) {
       let sumSmallestSubsetSize = 0;
       let sumSmallestOriginalSize = 0;
+      let maxUsedCodePoints = 0;
+      let maxOriginalCodePoints = 0;
       for (const fontUsage of fontUsages) {
         sumSmallestSubsetSize += fontUsage.smallestSubsetSize;
         sumSmallestOriginalSize += fontUsage.smallestOriginalSize;
+        maxUsedCodePoints = Math.max(
+          fontUsage.codepoints.used.length,
+          maxUsedCodePoints
+        );
+        maxOriginalCodePoints = Math.max(
+          fontUsage.codepoints.original.length,
+          maxOriginalCodePoints
+        );
       }
+      const fontUsagesByFontFamily = groupBy(
+        fontUsages,
+        fontUsage => fontUsage.props['font-family']
+      );
+      const numFonts = Object.keys(fontUsagesByFontFamily).length;
       console.log(
-        `${htmlAsset}: ${
+        `${htmlAsset}: ${numFonts} font${numFonts === 1 ? '' : 's'} (${
           fontUsages.length
-        } font variant(s) in use, ${prettyBytes(
+        } variant${fontUsages.length === 1 ? '' : 's'}) in use, ${prettyBytes(
           sumSmallestOriginalSize
         )} total. Created subsets: ${prettyBytes(sumSmallestSubsetSize)} total`
       );
+      for (const fontFamily of Object.keys(fontUsagesByFontFamily).sort()) {
+        console.log(`  ${fontFamily}:`);
+        for (const fontUsage of fontUsagesByFontFamily[fontFamily]) {
+          const variantShortName = `${fontUsage.props['font-weight']}${
+            fontUsage.props['font-style'] === 'italic' ? 'i' : ' '
+          }`;
+          console.log(
+            `    ${variantShortName}: ${String(
+              fontUsage.codepoints.used.length
+            ).padStart(String(maxUsedCodePoints).length)}/${String(
+              fontUsage.codepoints.original.length
+            ).padStart(
+              String(maxOriginalCodePoints).length
+            )} codepoints used, ${prettyBytes(
+              fontUsage.smallestOriginalSize
+            )} => ${prettyBytes(fontUsage.smallestSubsetSize)}`
+          );
+          totalSavings +=
+            fontUsage.smallestOriginalSize - fontUsage.smallestSubsetSize;
+        }
+      }
     }
+    console.log(`Total savings: ${prettyBytes(totalSavings)}`);
     console.log('Output written to', outRoot || assetGraph.root);
   } catch (err) {
     console.log(err.stack);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/Munter/subfont#readme",
   "dependencies": {
     "assetgraph": "^4.11.0",
+    "lodash.groupby": "^4.6.0",
     "pretty-bytes": "^5.1.0",
     "urltools": "^0.3.5",
     "yargs": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/Munter/subfont#readme",
   "dependencies": {
     "assetgraph": "^4.11.0",
+    "pretty-bytes": "^5.1.0",
     "urltools": "^0.3.5",
     "yargs": "^11.0.0"
   },


### PR DESCRIPTION
Prereq: https://github.com/assetgraph/assetgraph/pull/899

I thought I'd get subfont to output this summary info instead of calculating it by hand while QAing :)

It could be nice to also include more verbose info for each font variant (maybe grouped by `font-family`) such as the number of glyphs in the subset and the original. I don't think we have the latter available, so it might be something to add after we've implemented the injection of `unicode-range` into the original `@font-face` declarations -- as that will need to extract the list of glyphs in the original.