### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "8.11"
-  - "9"
+  - "8"
   - "10"
+  - "node"
 
 addons:
   apt:


### PR DESCRIPTION
Node.js 9 has reached its EOL and we should check the current LTS 8 and 10 and current stable (11) - to fail early.