### PR TITLE
Avoid an unhandled rejection if the font preload polyfill fails for some reason

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -937,7 +937,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
           formatMap[preloadRelation.to.extension]
         }')",
             ${JSON.stringify(props)}
-          ).load();`;
+          ).load().then(void 0, function () {});`;
       });
 
       const originalFontJsPreloadAsset = htmlAsset.addRelation(
@@ -1083,7 +1083,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
           to: {
             type: 'JavaScript',
             text:
-              'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load(); }); } catch (e) {}'
+              'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load().then(void 0, function () {}); }); } catch (e) {}'
           }
         },
         'after',


### PR DESCRIPTION
I ran into some unhandled rejections with the headless browser, and I think they could occur in a real browser, too.