### PR TITLE
Don't memoize getFontFaceForFontUsage, it goes bad when running subsetFonts multiple times

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -454,56 +454,47 @@ const fontContentTypeMap = {
 
 const fontOrder = ['woff2', 'woff', 'truetype'];
 
-const getFontFaceForFontUsage = memoizeSync(
-  fontUsage => {
-    const subsets = fontOrder
-      .filter(format => fontUsage.subsets[format])
-      .map(format => ({
-        format,
-        url: `data:${fontContentTypeMap[format]};base64,${fontUsage.subsets[
-          format
-        ].toString('base64')}`
-      }));
+function getFontFaceForFontUsage(fontUsage) {
+  const subsets = fontOrder
+    .filter(format => fontUsage.subsets[format])
+    .map(format => ({
+      format,
+      url: `data:${fontContentTypeMap[format]};base64,${fontUsage.subsets[
+        format
+      ].toString('base64')}`
+    }));
 
-    const resultString = ['@font-face {'];
+  const resultString = ['@font-face {'];
 
-    resultString.push(
-      ...Object.keys(fontUsage.props)
-        .sort()
-        .map(prop => {
-          let value = fontUsage.props[prop];
+  resultString.push(
+    ...Object.keys(fontUsage.props)
+      .sort()
+      .map(prop => {
+        let value = fontUsage.props[prop];
 
-          if (prop === 'font-family') {
-            value = cssQuoteIfNecessary(`${value}__subset`);
-          }
+        if (prop === 'font-family') {
+          value = cssQuoteIfNecessary(`${value}__subset`);
+        }
 
-          if (prop === 'src') {
-            value = subsets
-              .map(subset => `url(${subset.url}) format('${subset.format}')`)
-              .join(', ');
-          }
+        if (prop === 'src') {
+          value = subsets
+            .map(subset => `url(${subset.url}) format('${subset.format}')`)
+            .join(', ');
+        }
 
-          return `${prop}: ${value};`;
-        })
-        .map(str => `  ${str}`)
-    );
+        return `${prop}: ${value};`;
+      })
+      .map(str => `  ${str}`)
+  );
 
-    resultString.push(
-      `  unicode-range: ${unicodeRange(fontUsage.codepoints.used)};`
-    );
+  resultString.push(
+    `  unicode-range: ${unicodeRange(fontUsage.codepoints.used)};`
+  );
 
-    resultString.push('}');
+  resultString.push('}');
 
-    return resultString.join('\n');
-  },
-  {
-    argumentsStringifier: args => {
-      return [args[0].text, args[0].props, args[1]]
-        .map(arg => JSON.stringify(arg))
-        .join('\x1d');
-    }
-  }
-);
+  return resultString.join('\n');
+}
 
 function getUnusedVariantsStylesheet(
   fontUsages,


### PR DESCRIPTION
Discovered as part of https://github.com/Munter/subfont/pull/57

I guess we could consider memoizing it inside `subsetFonts`, though, but then the memoized function would have to be handed into a bunch of helper functions. Not sure it's worth it.