### PR TITLE
Avoid overloading fallback font with JS preload

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1085,7 +1085,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
           to: {
             type: 'JavaScript',
             text:
-              'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load().then(void 0, function () {}); }); } catch (e) {}'
+              'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.unicodeRange !== "U+0-10FFFF" && f.load().then(void 0, function () {}); }); } catch (e) {}'
           }
         },
         'after',


### PR DESCRIPTION
See https://gitter.im/assetgraph/assetgraph?at=5dba1974e1c5e915080435cb

No tests are failing, which means that we didn't test this situation.

On my local machine with subfont linked in, the unused font-variant now no longer gets loaded