### PR TITLE
Don't use the short document.fonts.forEach preload polyfill in inlineCss mode

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1076,99 +1076,79 @@ These glyphs are used on your site, but they don't exist in the font you applied
 
     // JS-based font preloading for browsers without <link rel="preload"> support
     let jsPreloadRelation;
-    if (inlineCss) {
-      // If the CSS is inlined we can use the font declarations directly to load the fonts
-      jsPreloadRelation = htmlAsset.addRelation(
-        {
-          type: 'HtmlScript',
-          hrefType: 'inline',
-          to: {
-            type: 'JavaScript',
-            text:
-              'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load().then(void 0, function () {}); }); } catch (e) {}'
+    const fontFaceContructorCalls = [];
+
+    cssAsset.parseTree.walkAtRules('font-face', rule => {
+      let name;
+      let url;
+      const props = {};
+
+      rule.walkDecls(({ prop, value }) => {
+        const propName = prop.toLowerCase();
+        if (propName === 'font-weight') {
+          value = value
+            .split(/\s+/)
+            .map(token => normalizeFontPropertyValue('font-weight', token))
+            .join(' ');
+          if (/^\d+$/.test(value)) {
+            value = parseInt(value, 10);
           }
-        },
-        'after',
-        cssRelation
-      );
-      jsPreloadRelation.to.minify();
-    } else {
-      // The CSS is external, can't use the font face declarations without waiting for a blocking load.
-      // Go for direct FontFace construction instead
-      const fontFaceContructorCalls = [];
+        }
 
-      cssAsset.parseTree.walkAtRules('font-face', rule => {
-        let name;
-        let url;
-        const props = {};
-
-        rule.walkDecls(({ prop, value }) => {
-          const propName = prop.toLowerCase();
-          if (propName === 'font-weight') {
-            value = value
-              .split(/\s+/)
-              .map(token => normalizeFontPropertyValue('font-weight', token))
-              .join(' ');
-            if (/^\d+$/.test(value)) {
-              value = parseInt(value, 10);
-            }
+        if (propName in initialValueByProp) {
+          if (
+            normalizeFontPropertyValue(propName, value) !==
+            normalizeFontPropertyValue(propName, initialValueByProp[propName])
+          ) {
+            props[propName] = value;
           }
+        }
 
-          if (propName in initialValueByProp) {
-            if (
-              normalizeFontPropertyValue(propName, value) !==
-              normalizeFontPropertyValue(propName, initialValueByProp[propName])
-            ) {
-              props[propName] = value;
-            }
-          }
-
-          if (propName === 'font-family') {
-            name = unquote(value);
-          } else if (propName === 'src') {
-            const fontRelations = cssAsset.outgoingRelations.filter(
-              relation => relation.node === rule
-            );
-            const urlStrings = value
-              .split(/,\s*/)
-              .filter(entry => entry.startsWith('url('));
-            const urlValues = urlStrings.map((urlString, idx) =>
-              urlString.replace(
-                fontRelations[idx].href,
-                '" + "/__subfont__".toString("url") + "'
-              )
-            );
-            url = `"${urlValues.join(', ')}"`;
-          }
-        });
-
-        fontFaceContructorCalls.push(
-          `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
-        );
+        if (propName === 'font-family') {
+          name = unquote(value);
+        } else if (propName === 'src') {
+          const fontRelations = cssAsset.outgoingRelations.filter(
+            relation => relation.node === rule
+          );
+          const urlStrings = value
+            .split(/,\s*/)
+            .filter(entry => entry.startsWith('url('));
+          const urlValues = urlStrings.map((urlString, idx) =>
+            urlString.replace(
+              fontRelations[idx].href,
+              '" + "/__subfont__".toString("url") + "'
+            )
+          );
+          url = `"${urlValues.join(', ')}"`;
+        }
       });
 
-      jsPreloadRelation = htmlAsset.addRelation(
-        {
-          type: 'HtmlScript',
-          hrefType: 'inline',
-          to: {
-            type: 'JavaScript',
-            text: `try {${fontFaceContructorCalls.join('')}} catch (e) {}`
-          }
-        },
-        'before',
-        cssRelation
+      fontFaceContructorCalls.push(
+        `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
       );
+    });
 
-      for (const [
-        idx,
-        relation
-      ] of jsPreloadRelation.to.outgoingRelations.entries()) {
-        potentiallyOrphanedAssets.add(relation.to);
-        relation.to = cssAsset.outgoingRelations[idx].to;
-        relation.hrefType = 'rootRelative';
-        relation.refreshHref();
-      }
+    jsPreloadRelation = htmlAsset.addRelation(
+      {
+        type: 'HtmlScript',
+        hrefType: 'inline',
+        to: {
+          type: 'JavaScript',
+          text: `try {${fontFaceContructorCalls.join('')}} catch (e) {}`
+        }
+      },
+      'before',
+      cssRelation
+    );
+
+    for (const [
+      idx,
+      relation
+    ] of jsPreloadRelation.to.outgoingRelations.entries()) {
+      potentiallyOrphanedAssets.add(relation.to);
+      relation.to = cssAsset.outgoingRelations[idx].to;
+      relation.hrefType = 'rootRelative';
+      relation.refreshHref();
     }
 
     jsPreloadRelation.to.minify();

--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1075,7 +1075,6 @@ These glyphs are used on your site, but they don't exist in the font you applied
     );
 
     // JS-based font preloading for browsers without <link rel="preload"> support
-    let jsPreloadRelation;
     const fontFaceContructorCalls = [];
 
     cssAsset.parseTree.walkAtRules('font-face', rule => {
@@ -1128,7 +1127,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
       );
     });
 
-    jsPreloadRelation = htmlAsset.addRelation(
+    const jsPreloadRelation = htmlAsset.addRelation(
       {
         type: 'HtmlScript',
         hrefType: 'inline',

--- a/test/subsetFonts.js
+++ b/test/subsetFonts.js
@@ -483,7 +483,6 @@ describe('subsetFonts', function() {
         expect(assetGraph, 'to contain asset', { fileName: 'index.html' });
 
         const index = assetGraph.findAssets({ fileName: 'index.html' })[0];
-
         expect(index.outgoingRelations, 'to satisfy', [
           {
             type: 'HtmlPreloadLink',
@@ -493,6 +492,16 @@ describe('subsetFonts', function() {
               isLoaded: true
             },
             as: 'font'
+          },
+          {
+            type: 'HtmlScript',
+            to: {
+              type: 'JavaScript',
+              isInline: true,
+              text: expect
+                .it('to contain', "new FontFace('Open Sans__subset','url(")
+                .and('to contain', '__subset')
+            }
           },
           {
             type: 'HtmlStyle',
@@ -529,16 +538,6 @@ describe('subsetFonts', function() {
             type: 'HtmlPreconnectLink',
             hrefType: 'absolute',
             href: 'https://fonts.gstatic.com'
-          },
-          {
-            type: 'HtmlScript',
-            to: {
-              type: 'JavaScript',
-              isInline: true,
-              text: expect
-                .it('to contain', 'document.fonts.forEach')
-                .and('to contain', '__subset')
-            }
           },
           {
             type: 'HtmlStyle',


### PR DESCRIPTION
It's too sensitive to bundlers, so let's just eat the extra bytes: https://gitter.im/assetgraph/assetgraph?at=5dba0800ef84ab3786c862e3