### PR TITLE
Add subsetPerPage & format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Options:
   --font-display                     Injects a font-display value into the @font-face CSS. Valid
                                      values: auto, block, swap, fallback, optional
              [string] [choices: "auto", "block", "swap", "fallback", "optional"] [default: "swap"]
+  --formats                          Font formats to use when subsetting.
+             [array]  [choices: "woff2", "woff", "truetype"] [default: ["woff2","woff"]]
+  --subset-per-page                  Create a unique subset for each page.
+                                                                        [boolean] [default: false]
   --recursive, -r                    Crawl all HTML-pages linked with relative and root relative
                                      links. This stays inside your domain
                                                                         [boolean] [default: false]

--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -61,6 +61,19 @@ module.exports = function parseCommandLineOptions(argv) {
       default: 'swap',
       choices: ['auto', 'block', 'swap', 'fallback', 'optional']
     })
+    .options('formats', {
+      describe:
+        'Font formats to use when subsetting.',
+      type: 'array',
+      default: ['woff2', 'woff'],
+      choices: ['woff2', 'woff', 'truetype']
+    })
+    .options('subset-per-page', {
+      describe:
+        'Create a unique subset for each page.',
+      type: 'boolean',
+      default: false
+    })
     .options('recursive', {
       alias: 'r',
       describe:

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -16,6 +16,8 @@ module.exports = async function subfont(
     inlineFonts = false,
     inlineCss = false,
     fontDisplay = 'swap',
+    formats = ['woff2', 'woff'],
+    subsetPerPage = false,
     inPlace = false,
     inputFiles = [],
     recursive = false,
@@ -147,6 +149,8 @@ module.exports = async function subfont(
     inlineFonts,
     inlineCss,
     fontDisplay,
+    subsetPerPage,
+    formats,
     omitFallbacks: !fallbacks,
     dynamic,
     console


### PR DESCRIPTION
I'm switching over from using `subsetFonts` from AssetGraph and I currently use both of these features.