### PR TITLE
Don't attempt to prefetch inlined fonts

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1091,83 +1091,87 @@ These glyphs are used on your site, but they don't exist in the font you applied
       insertionPoint
     );
 
-    // JS-based font preloading for browsers without <link rel="preload"> support
-    const fontFaceContructorCalls = [];
+    let cssAssetInsertion = cssRelation;
+    if (!inlineFonts) {
+      // JS-based font preloading for browsers without <link rel="preload"> support
+      const fontFaceContructorCalls = [];
 
-    cssAsset.parseTree.walkAtRules('font-face', rule => {
-      let name;
-      let url;
-      const props = {};
+      cssAsset.parseTree.walkAtRules('font-face', rule => {
+        let name;
+        let url;
+        const props = {};
 
-      rule.walkDecls(({ prop, value }) => {
-        const propName = prop.toLowerCase();
-        if (propName === 'font-weight') {
-          value = value
-            .split(/\s+/)
-            .map(token => normalizeFontPropertyValue('font-weight', token))
-            .join(' ');
-          if (/^\d+$/.test(value)) {
-            value = parseInt(value, 10);
+        rule.walkDecls(({ prop, value }) => {
+          const propName = prop.toLowerCase();
+          if (propName === 'font-weight') {
+            value = value
+              .split(/\s+/)
+              .map(token => normalizeFontPropertyValue('font-weight', token))
+              .join(' ');
+            if (/^\d+$/.test(value)) {
+              value = parseInt(value, 10);
+            }
           }
-        }
 
-        if (propName in initialValueByProp) {
-          if (
-            normalizeFontPropertyValue(propName, value) !==
-            normalizeFontPropertyValue(propName, initialValueByProp[propName])
-          ) {
-            props[propName] = value;
+          if (propName in initialValueByProp) {
+            if (
+              normalizeFontPropertyValue(propName, value) !==
+              normalizeFontPropertyValue(propName, initialValueByProp[propName])
+            ) {
+              props[propName] = value;
+            }
           }
-        }
 
-        if (propName === 'font-family') {
-          name = unquote(value);
-        } else if (propName === 'src') {
-          const fontRelations = cssAsset.outgoingRelations.filter(
-            relation => relation.node === rule
-          );
-          const urlStrings = value
-            .split(/,\s*/)
-            .filter(entry => entry.startsWith('url('));
-          const urlValues = urlStrings.map((urlString, idx) =>
-            urlString.replace(
-              fontRelations[idx].href,
-              '" + "/__subfont__".toString("url") + "'
-            )
-          );
-          url = `"${urlValues.join(', ')}"`;
-        }
+          if (propName === 'font-family') {
+            name = unquote(value);
+          } else if (propName === 'src') {
+            const fontRelations = cssAsset.outgoingRelations.filter(
+              relation => relation.node === rule
+            );
+            const urlStrings = value
+              .split(/,\s*/)
+              .filter(entry => entry.startsWith('url('));
+            const urlValues = urlStrings.map((urlString, idx) =>
+              urlString.replace(
+                fontRelations[idx].href,
+                '" + "/__subfont__".toString("url") + "'
+              )
+            );
+            url = `"${urlValues.join(', ')}"`;
+          }
+        });
+
+        fontFaceContructorCalls.push(
+          `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
+        );
       });
 
-      fontFaceContructorCalls.push(
-        `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
+      const jsPreloadRelation = htmlAsset.addRelation(
+        {
+          type: 'HtmlScript',
+          hrefType: 'inline',
+          to: {
+            type: 'JavaScript',
+            text: `try {${fontFaceContructorCalls.join('')}} catch (e) {}`
+          }
+        },
+        'before',
+        cssRelation
       );
-    });
 
-    const jsPreloadRelation = htmlAsset.addRelation(
-      {
-        type: 'HtmlScript',
-        hrefType: 'inline',
-        to: {
-          type: 'JavaScript',
-          text: `try {${fontFaceContructorCalls.join('')}} catch (e) {}`
-        }
-      },
-      'before',
-      cssRelation
-    );
+      for (const [
+        idx,
+        relation
+      ] of jsPreloadRelation.to.outgoingRelations.entries()) {
+        potentiallyOrphanedAssets.add(relation.to);
+        relation.to = cssAsset.outgoingRelations[idx].to;
+        relation.hrefType = 'rootRelative';
+        relation.refreshHref();
+      }
 
-    for (const [
-      idx,
-      relation
-    ] of jsPreloadRelation.to.outgoingRelations.entries()) {
-      potentiallyOrphanedAssets.add(relation.to);
-      relation.to = cssAsset.outgoingRelations[idx].to;
-      relation.hrefType = 'rootRelative';
-      relation.refreshHref();
+      jsPreloadRelation.to.minify();
+      cssAssetInsertion = jsPreloadRelation;
     }
-
-    jsPreloadRelation.to.minify();
 
     if (!omitFallbacks && inlineCss && unusedVariantsCss) {
       // The fallback CSS for unused variants needs to go into its own stylesheet after the crude version of the JS-based preload "polyfill"
@@ -1180,7 +1184,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
           }
         },
         'after',
-        jsPreloadRelation
+        cssAssetInsertion
       ).to;
       for (const relation of cssAsset.outgoingRelations) {
         relation.hrefType = 'rootRelative';


### PR DESCRIPTION
Currently if you inline fonts `subsetFonts` will still try to prefetch the font using Javascript and you end up with:
```
<script>try{new FontFace('FONT__subset','url(data:font/woff2;base64',{'font-weight':'800'}).load()}catch(e){}</script>
```
which just gives network errors.

This PR just ignores JS preloading if we are inlining fonts.