### PR TITLE
Don't refer to the fallback CSS with an absolute url when inside the canonical root

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -227,7 +227,10 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation) {
         text: `
           (function () {
             var el = document.createElement('link');
-            el.href = '${originalRelation.to.url}'.toString('url');
+            el.href = '${htmlAsset.assetGraph.buildRootRelativeUrl(
+              originalRelation.to.url,
+              htmlAsset.url
+            )}'.toString('url');
             el.rel = 'stylesheet';
             ${
               originalRelation.media
@@ -241,8 +244,6 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation) {
     },
     'lastInBody'
   );
-
-  asyncCssLoadingRelation.to.outgoingRelations[0].hrefType = 'rootRelative';
 
   // Insert <noscript> fallback sync CSS loading
   const noScriptFallbackRelation = htmlAsset.addRelation(


### PR DESCRIPTION
Fixes https://gitter.im/assetgraph/assetgraph?at=5ece5da89da05a060a3417fc