### PR TITLE
Warn if fetching an entry point results in an HTTP redirect

### DIFF
--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -140,7 +140,9 @@ module.exports = async function subfont(
     .findRelations({ type: 'HttpRedirect' })
     .sort((a, b) => a.id - b.id)) {
     if (relation.from.isInitial) {
-      console.warn(`${relation.from.url} redirected to ${relation.to.url}`);
+      assetGraph.info(
+        new Error(`${relation.from.url} redirected to ${relation.to.url}`)
+      );
       relation.to.isInitial = true;
       relation.from.isInitial = false;
     }

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -250,6 +250,7 @@ module.exports = async function subfont(
     await assetGraph.writeAssetsToDisc(
       {
         isLoaded: true,
+        isRedirect: { $ne: true },
         url: (url) => url.startsWith(assetGraph.root),
       },
       outRoot,

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -136,6 +136,16 @@ module.exports = async function subfont(
 
   await assetGraph.checkIncompatibleTypes();
 
+  for (const relation of assetGraph
+    .findRelations({ type: 'HttpRedirect' })
+    .sort((a, b) => a.id - b.id)) {
+    if (relation.from.isInitial) {
+      console.warn(`${relation.from.url} redirected to ${relation.to.url}`);
+      relation.to.isInitial = true;
+      relation.from.isInitial = false;
+    }
+  }
+
   let sumSizesBefore = 0;
   for (const asset of assetGraph.findAssets({
     isInline: false,

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -136,6 +136,8 @@ module.exports = async function subfont(
 
   await assetGraph.checkIncompatibleTypes();
 
+  const entrypointAssets = assetGraph.findAssets({ isInitial: true });
+  const redirectOrigins = new Set();
   for (const relation of assetGraph
     .findRelations({ type: 'HttpRedirect' })
     .sort((a, b) => a.id - b.id)) {
@@ -145,6 +147,22 @@ module.exports = async function subfont(
       );
       relation.to.isInitial = true;
       relation.from.isInitial = false;
+
+      redirectOrigins.add(relation.to.origin);
+    }
+  }
+  if (
+    entrypointAssets.length === redirectOrigins.size &&
+    redirectOrigins.size === 1
+  ) {
+    const newRoot = `${[...redirectOrigins][0]}/`;
+    if (newRoot !== assetGraph.root) {
+      assetGraph.info(
+        new Error(
+          `All entrypoints redirected, changing root from ${assetGraph.root} to ${newRoot}`
+        )
+      );
+      assetGraph.root = newRoot;
     }
   }
 

--- a/test/subfont.js
+++ b/test/subfont.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const expect = require('unexpected').clone().use(require('unexpected-sinon'));
 const subfont = require('../lib/subfont');
 const httpception = require('httpception');
+const AssetGraph = require('assetgraph');
 const proxyquire = require('proxyquire');
 const pathModule = require('path');
 const openSansBold = require('fs').readFileSync(
@@ -18,6 +19,10 @@ describe('subfont', function () {
   let mockConsole;
   beforeEach(async function () {
     mockConsole = { log: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+  });
+
+  afterEach(function () {
+    sinon.restore();
   });
 
   describe('when a font is referenced by a stylesheet hosted outside the root', function () {
@@ -265,6 +270,8 @@ describe('subfont', function () {
       ]);
 
       const root = 'http://example.com/';
+      sinon.stub(AssetGraph.prototype, 'info');
+
       const assetGraph = await subfont(
         {
           root,
@@ -286,9 +293,11 @@ describe('subfont', function () {
         'to equal',
         'https://somewhereelse.com/index.html'
       );
-      expect(mockConsole.warn, 'to have a call satisfying', () => {
-        mockConsole.warn(
-          'http://example.com/ redirected to https://somewhereelse.com/'
+      expect(assetGraph.info, 'to have a call satisfying', () => {
+        assetGraph.info(
+          new Error(
+            'http://example.com/ redirected to https://somewhereelse.com/'
+          )
         );
       });
     });


### PR DESCRIPTION
I ran into some small glitches when I tried to run subfont on `https://netlify.com/` because it gets redirected to `https://www.netlify.com/`. This helps a bit -- roughly copied from bringhome.