### PR TITLE
Do not preload unused variants in the JavaScript-based polyfill

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1150,22 +1150,26 @@ These glyphs are used on your site, but they don't exist in the font you applied
             const fontRelations = cssAsset.outgoingRelations.filter(
               (relation) => relation.node === rule
             );
-            const urlStrings = value
-              .split(/,\s*/)
-              .filter((entry) => entry.startsWith('url('));
+            const urlStrings = value.split(/,\s*/).filter(
+              (entry) => entry.startsWith('url(') && entry.includes('/subfont/') // Avoid preloading unused variants
+            );
             const urlValues = urlStrings.map((urlString, idx) =>
               urlString.replace(
                 fontRelations[idx].href,
                 '" + "/__subfont__".toString("url") + "'
               )
             );
-            url = `"${urlValues.join(', ')}"`;
+            if (urlValues.length > 0) {
+              url = `"${urlValues.join(', ')}"`;
+            }
           }
         });
 
-        fontFaceContructorCalls.push(
-          `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
-        );
+        if (url) {
+          fontFaceContructorCalls.push(
+            `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
+          );
+        }
       });
 
       const jsPreloadRelation = htmlAsset.addRelation(

--- a/test/subsetFonts.js
+++ b/test/subsetFonts.js
@@ -3563,6 +3563,39 @@ describe('subsetFonts', function () {
           url: `${assetGraph.root}IBMPlexSans-Italic.woff`,
         });
       });
+
+      it('should not preload the unused variants', async function () {
+        const assetGraph = new AssetGraph({
+          root: pathModule.resolve(
+            __dirname,
+            '../testdata/subsetFonts/unused-variant-preload/'
+          ),
+        });
+        const [htmlAsset] = await assetGraph.loadAssets('index.html');
+        await assetGraph.populate({
+          followRelations: {
+            crossorigin: false,
+          },
+        });
+        await subsetFonts(assetGraph, {
+          inlineFonts: false,
+        });
+        const [preloadPolyfill] = assetGraph.findAssets({
+          type: 'JavaScript',
+          text: { $regex: /new FontFace/ },
+        });
+        expect(preloadPolyfill.text, 'to contain', ".woff2'")
+          .and('to contain', ".woff'")
+          .and('not to contain', ".ttf'")
+          .and('not to contain', 'fonts.gstatic.com');
+        const preloadLinks = assetGraph.findRelations({
+          from: htmlAsset,
+          type: 'HtmlPreloadLink',
+        });
+        expect(preloadLinks, 'to satisfy', [
+          { href: /^\/subfont\/Noto_Serif-400-[a-f0-9]{10}\.woff2$/ },
+        ]);
+      });
     });
 
     it('should return a fontInfo object with defaulted/normalized props', async function () {

--- a/testdata/subsetFonts/unused-variant-preload/index.html
+++ b/testdata/subsetFonts/unused-variant-preload/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,700,400i|Open+Sans:700,400">
+  </head>
+  <body>
+    <div style="font-family: Noto Serif">Hello</div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #92

Addresses the problem discussed here: https://gitter.im/assetgraph/assetgraph?at=5ece6c29a91f120a6cc72bca

Looks like we only weed out the non-subfont-introduced fonts when adding the `<link rel="preload">`s, not the JavaScript-based polyfill.

The `User-Agent` thing I mentioned is a separate problem, since it means that the unused variants copied into the `__subset` font families will end up as .ttfs because they're based on the generic CSS from Google Web Fonts. We could fix that by providing `woff` and `woff2` alternatives as well. Let's discuss and try to address it separately.

This polyfill keeps biting us, maybe the state of web browsers is so that we can remove it soon?