### PR TITLE
Always include the space character U+20 in subsets

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -792,6 +792,12 @@ async function subsetFonts(
           const usedCodepoints = fontUsage.text
             .split('')
             .map((c) => c.codePointAt(0));
+          if (!usedCodepoints.includes(32)) {
+            // Make sure that space is always part of the subset fonts (and that it's announced in unicode-range).
+            // Prevents Chrome from going off and downloading the fallback:
+            // https://gitter.im/assetgraph/assetgraph?at=5f01f6e13a0d3931fad4021b
+            usedCodepoints.push(32);
+          }
           const unusedCodepoints = originalCodepoints.filter(
             (n) => !usedCodepoints.includes(n)
           );

--- a/test/subsetFonts.js
+++ b/test/subsetFonts.js
@@ -515,7 +515,7 @@ describe('subsetFonts', function () {
                 fontFamilies: expect.it('to be a', Set),
                 codepoints: {
                   original: expect.it('to be an array'),
-                  used: [101, 108, 111, 72],
+                  used: [101, 108, 111, 32, 72],
                   unused: expect.it('to be an array'),
                 },
               },


### PR DESCRIPTION
... to prevent Chrome from downloading the fallback font.

https://gitter.im/assetgraph/assetgraph?at=5f01f6e13a0d3931fad4021b