### PR TITLE
Self host fallback CSS and fonts for Google Web Fonts

### DIFF
--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1382,6 +1382,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
     type: 'Css',
     url: { $regex: googleFontsCssUrlRegex },
   });
+  const selfHostedGoogleCssByUrl = new Map();
   for (const googleFontStylesheet of googleFontStylesheets) {
     const seenPages = new Set(); // Only do the work once for each font on each page
     for (const googleFontStylesheetRelation of googleFontStylesheet.incomingRelations) {
@@ -1406,12 +1407,21 @@ These glyphs are used on your site, but they don't exist in the font you applied
         seenPages.add(htmlParent);
 
         if (!omitFallbacks) {
-          const selfHostedGoogleFontsCssAsset = await createSelfHostedGoogleFontsCssAsset(
-            assetGraph,
-            googleFontStylesheetRelation.to,
-            formats
+          let selfHostedGoogleFontsCssAsset = selfHostedGoogleCssByUrl.get(
+            googleFontStylesheetRelation.to.url
           );
-          subsetFontsToBeMinified.add(selfHostedGoogleFontsCssAsset);
+          if (!selfHostedGoogleFontsCssAsset) {
+            selfHostedGoogleFontsCssAsset = await createSelfHostedGoogleFontsCssAsset(
+              assetGraph,
+              googleFontStylesheetRelation.to,
+              formats
+            );
+            subsetFontsToBeMinified.add(selfHostedGoogleFontsCssAsset);
+            selfHostedGoogleCssByUrl.set(
+              googleFontStylesheetRelation.to.url,
+              selfHostedGoogleFontsCssAsset
+            );
+          }
           const selfHostedFallbackRelation = htmlParent.addRelation(
             {
               type: 'HtmlStyle',

--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -585,6 +585,11 @@ async function createSelfHostedGoogleFontsCssAsset(
       );
     }
     lines.push(`  src: ${srcFragments.join(', ')};`, '}');
+    lines.push(
+      `  unicode-range: ${unicodeRange(
+        fontkit.create(cssFontFaceSrc.to.rawSrc).characterSet
+      )};`
+    );
   }
   const text = lines.join('\n');
   const fallbackAsset = assetGraph.addAsset({

--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -20,6 +20,7 @@ const cssListHelpers = require('css-list-helpers');
 const LinesAndColumns = require('lines-and-columns').default;
 const fontkit = require('fontkit');
 const fontFamily = require('font-family-papandreou');
+const crypto = require('crypto');
 
 const unquote = require('./unquote');
 const normalizeFontPropertyValue = require('./normalizeFontPropertyValue');
@@ -197,22 +198,6 @@ function getParents(assetGraph, asset, assetQuery) {
   })(asset);
 
   return parents;
-}
-
-function insertPreconnect(
-  htmlAsset,
-  hostname,
-  insertPoint = htmlAsset.outgoingRelations[0]
-) {
-  return htmlAsset.addRelation(
-    {
-      type: 'HtmlPreconnectLink',
-      hrefType: 'absolute',
-      to: { url: `https://${hostname}` },
-    },
-    'after',
-    insertPoint
-  );
 }
 
 function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation) {
@@ -550,6 +535,64 @@ function getFontUsageStylesheet(fontUsages) {
     .filter((fontUsage) => fontUsage.subsets)
     .map((fontUsage) => getFontFaceForFontUsage(fontUsage))
     .join('\n\n');
+}
+
+const extensionByFormat = {
+  truetype: '.ttf',
+  woff: '.woff',
+  woff2: '.woff2',
+};
+
+function md5HexPrefix(stringOrBuffer) {
+  return crypto
+    .createHash('md5')
+    .update(stringOrBuffer)
+    .digest('hex')
+    .slice(0, 10);
+}
+
+async function createSelfHostedGoogleFontsCssAsset(
+  assetGraph,
+  googleFontsCssAsset,
+  formats
+) {
+  const lines = [];
+  for (const cssFontFaceSrc of assetGraph.findRelations({
+    from: googleFontsCssAsset,
+    type: 'CssFontFaceSrc',
+  })) {
+    lines.push(`@font-face {`);
+    const fontFaceDeclaration = cssFontFaceSrc.node;
+    fontFaceDeclaration.walkDecls((declaration) => {
+      const propName = declaration.prop.toLowerCase();
+      if (propName !== 'src') {
+        lines.push(`  ${propName}: ${declaration.value};`);
+      }
+    });
+    const srcFragments = [];
+    for (const format of formats) {
+      const rawSrc = await convertFontBuffer(cssFontFaceSrc.to.rawSrc, format);
+      const fontAsset = await assetGraph.addAsset({
+        url: `/subfont/${cssFontFaceSrc.to.baseName}-${md5HexPrefix(rawSrc)}${
+          extensionByFormat[format]
+        }`,
+        rawSrc,
+      });
+      srcFragments.push(
+        `url(${assetGraph.buildRootRelativeUrl(
+          fontAsset.url
+        )}) format('${format}')`
+      );
+    }
+    lines.push(`  src: ${srcFragments.join(', ')};`, '}');
+  }
+  const text = lines.join('\n');
+  const fallbackAsset = assetGraph.addAsset({
+    type: 'Css',
+    url: `/subfont/fallback-${md5HexPrefix(text)}.css`,
+    text,
+  });
+  return fallbackAsset;
 }
 
 const validFontDisplayValues = [
@@ -1362,33 +1405,28 @@ These glyphs are used on your site, but they don't exist in the font you applied
         }
         seenPages.add(htmlParent);
 
-        let insertPoint = htmlParent.outgoingRelations.find(
-          (relation) => relation.type === 'HtmlStyle'
-        );
-
-        if (omitFallbacks) {
-          googleFontStylesheetRelation.detach();
-        } else {
-          // Resource hint: preconnect to the Google font stylesheet hostname
-          insertPoint = insertPreconnect(
-            htmlParent,
-            googleFontStylesheetRelation.to.hostname,
-            insertPoint
+        if (!omitFallbacks) {
+          const selfHostedGoogleFontsCssAsset = await createSelfHostedGoogleFontsCssAsset(
+            assetGraph,
+            googleFontStylesheetRelation.to,
+            formats
           );
-
-          // Resource hint: preconnect to the Google font hostname
-          insertPreconnect(
-            htmlParent,
-            googleFontStylesheetRelation.to.outgoingRelations[0].to.hostname,
-            insertPoint
+          subsetFontsToBeMinified.add(selfHostedGoogleFontsCssAsset);
+          const selfHostedFallbackRelation = htmlParent.addRelation(
+            {
+              type: 'HtmlStyle',
+              to: selfHostedGoogleFontsCssAsset,
+              hrefType: 'rootRelative',
+            },
+            'lastInBody'
           );
-
+          relationsToRemove.add(selfHostedFallbackRelation);
           asyncLoadStyleRelationWithFallback(
             htmlParent,
-            googleFontStylesheetRelation
+            selfHostedFallbackRelation
           );
-          relationsToRemove.add(googleFontStylesheetRelation);
         }
+        relationsToRemove.add(googleFontStylesheetRelation);
       }
     }
     googleFontStylesheet.unload();

--- a/test/subsetFonts.js
+++ b/test/subsetFonts.js
@@ -401,16 +401,6 @@ describe('subsetFonts', function () {
           },
         },
         {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.googleapis.com',
-        },
-        {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.gstatic.com',
-        },
-        {
           type: 'HtmlStyle',
           to: {
             isInline: true,
@@ -424,7 +414,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'JavaScriptStaticUrl',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -438,7 +431,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'HtmlStyle',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -578,16 +574,6 @@ describe('subsetFonts', function () {
             },
           },
           {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.googleapis.com',
-          },
-          {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.gstatic.com',
-          },
-          {
             type: 'HtmlStyle',
             to: {
               isInline: true,
@@ -601,7 +587,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'JavaScriptStaticUrl',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -615,7 +604,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'HtmlStyle',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -719,16 +711,6 @@ describe('subsetFonts', function () {
           },
         },
         {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.googleapis.com',
-        },
-        {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.gstatic.com',
-        },
-        {
           type: 'HtmlStyle',
           to: {
             isInline: true,
@@ -742,7 +724,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'JavaScriptStaticUrl',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -756,7 +741,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'HtmlStyle',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -1344,16 +1332,6 @@ describe('subsetFonts', function () {
           },
         },
         {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.googleapis.com',
-        },
-        {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.gstatic.com',
-        },
-        {
           type: 'HtmlStyle',
           to: {
             isInline: true,
@@ -1370,8 +1348,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'JavaScriptStaticUrl',
-                href:
-                  'https://fonts.googleapis.com/css?family=Jim+Nightshade|Montserrat|Space+Mono',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -1385,8 +1365,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'HtmlStyle',
-                href:
-                  'https://fonts.googleapis.com/css?family=Jim+Nightshade|Montserrat|Space+Mono',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -1764,16 +1746,6 @@ describe('subsetFonts', function () {
           },
         },
         {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.googleapis.com',
-        },
-        {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.gstatic.com',
-        },
-        {
           type: 'HtmlStyle',
           to: {
             isInline: true,
@@ -1787,8 +1759,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'JavaScriptStaticUrl',
-                href:
-                  'https://fonts.googleapis.com/css?family=Roboto:300i,400,500',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -1802,8 +1776,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'HtmlStyle',
-                href:
-                  'https://fonts.googleapis.com/css?family=Roboto:300i,400,500',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -2011,6 +1987,20 @@ describe('subsetFonts', function () {
                 ],
               },
             },
+            {
+              type: 'HtmlStyle',
+              to: {
+                path: '/subfont/',
+                fileName: /^fallback-[a-f0-9]{10}\.css$/,
+              },
+            },
+            {
+              type: 'HtmlStyle',
+              to: {
+                path: '/subfont/',
+                fileName: /^fallback-[a-f0-9]{10}\.css$/,
+              },
+            },
           ]
         );
 
@@ -2064,16 +2054,6 @@ describe('subsetFonts', function () {
             },
           },
           {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.googleapis.com',
-          },
-          {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.gstatic.com',
-          },
-          {
             type: 'HtmlStyle',
             to: { isInline: true },
           },
@@ -2088,7 +2068,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'JavaScriptStaticUrl',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2102,7 +2085,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'HtmlStyle',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2158,16 +2144,6 @@ describe('subsetFonts', function () {
             to: expect.it('not to be', indexFontStyle),
           },
           {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.googleapis.com',
-          },
-          {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.gstatic.com',
-          },
-          {
             type: 'HtmlStyle',
             to: { isInline: true },
           },
@@ -2182,7 +2158,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'JavaScriptStaticUrl',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2196,7 +2175,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'HtmlStyle',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2351,16 +2333,6 @@ describe('subsetFonts', function () {
             },
           },
           {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.googleapis.com',
-          },
-          {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.gstatic.com',
-          },
-          {
             type: 'HtmlStyle',
             to: { isInline: true },
           },
@@ -2375,7 +2347,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'JavaScriptStaticUrl',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2389,7 +2364,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'HtmlStyle',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2442,16 +2420,6 @@ describe('subsetFonts', function () {
             to: sharedFontStyles,
           },
           {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.googleapis.com',
-          },
-          {
-            type: 'HtmlPreconnectLink',
-            hrefType: 'absolute',
-            href: 'https://fonts.gstatic.com',
-          },
-          {
             type: 'HtmlStyle',
             to: { isInline: true },
           },
@@ -2466,7 +2434,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'JavaScriptStaticUrl',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -2480,7 +2451,10 @@ describe('subsetFonts', function () {
               outgoingRelations: [
                 {
                   type: 'HtmlStyle',
-                  href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                  to: {
+                    path: '/subfont/',
+                    fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                  },
                 },
               ],
             },
@@ -3649,16 +3623,6 @@ describe('subsetFonts', function () {
           },
         },
         {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.googleapis.com',
-        },
-        {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.gstatic.com',
-        },
-        {
           type: 'HtmlStyle',
           to: {
             isInline: true,
@@ -3672,7 +3636,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'JavaScriptStaticUrl',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -3686,7 +3653,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'HtmlStyle',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -3937,16 +3907,6 @@ describe('subsetFonts', function () {
           },
         },
         {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.googleapis.com',
-        },
-        {
-          type: 'HtmlPreconnectLink',
-          hrefType: 'absolute',
-          href: 'https://fonts.gstatic.com',
-        },
-        {
           type: 'HtmlStyle',
           to: {
             isInline: true,
@@ -3970,7 +3930,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'JavaScriptStaticUrl',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },
@@ -3984,7 +3947,10 @@ describe('subsetFonts', function () {
             outgoingRelations: [
               {
                 type: 'HtmlStyle',
-                href: 'https://fonts.googleapis.com/css?family=Open+Sans',
+                to: {
+                  path: '/subfont/',
+                  fileName: /^fallback-[a-f0-9]{10}\.css$/,
+                },
               },
             ],
           },


### PR DESCRIPTION
Fixes #31

We can simplify this a lot if/when we let go of the requirement to use Google Web Font's subsetting features. That'll pave the way to run a "self host" step early in the process and share the rest of the code.