### PR TITLE
Use browserslist to configure which font formats to supply subsets and fallbacks in, and whether to add the JS-based preload polyfill

### DIFF
--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -32,6 +32,12 @@ module.exports = function parseCommandLineOptions(argv) {
       type: 'string',
       demand: false,
     })
+    .options('formats', {
+      describe:
+        'Font formats to use when subsetting. The default is to select the formats based on the browser capabilities as specified via --browsers or the browserslist configuration.',
+      type: 'array',
+      choices: ['woff2', 'woff', 'truetype'],
+    })
     .options('fallbacks', {
       describe:
         'Include fallbacks so the original font will be loaded when dynamic content gets injected at runtime. Disable with --no-fallbacks',
@@ -66,12 +72,6 @@ module.exports = function parseCommandLineOptions(argv) {
       type: 'string',
       default: 'swap',
       choices: ['auto', 'block', 'swap', 'fallback', 'optional'],
-    })
-    .options('formats', {
-      describe:
-        'Font formats to use when subsetting. The default is to select the formats based on the browser capabilities as specified via --browsers or the browserslist configuration.',
-      type: 'array',
-      choices: ['woff2', 'woff', 'truetype'],
     })
     .options('subset-per-page', {
       describe: 'Create a unique subset for each page.',

--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -39,11 +39,6 @@ module.exports = function parseCommandLineOptions(argv) {
       type: 'array',
       choices: ['woff2', 'woff', 'truetype'],
     })
-    .options('js-preload', {
-      describe:
-        'Whether to include a JavaScript-based "polyfill" for browsers that do not support <link rel=preload>. The default is based on whether --browsers or the browserslist configuration specifies a browser that needs it. Disable with --no-js-preload',
-      type: 'boolean',
-    })
     .options('fallbacks', {
       describe:
         'Include fallbacks so the original font will be loaded when dynamic content gets injected at runtime. Disable with --no-fallbacks',

--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -38,6 +38,11 @@ module.exports = function parseCommandLineOptions(argv) {
       type: 'array',
       choices: ['woff2', 'woff', 'truetype'],
     })
+    .options('js-preload', {
+      describe:
+        'Whether to include a JavaScript-based "polyfill" for browsers that do not support <link rel=preload>. The default is based on whether --browsers or the browserslist configuration specifies a browser that needs it. Disable with --no-js-preload',
+      type: 'boolean',
+    })
     .options('fallbacks', {
       describe:
         'Include fallbacks so the original font will be loaded when dynamic content gets injected at runtime. Disable with --no-fallbacks',

--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -28,8 +28,7 @@ module.exports = function parseCommandLineOptions(argv) {
     })
     .options('browsers', {
       describe:
-        "Specify which browsers to support. Controls which font formats to provide, and whether to apply a JavaScript-based polyfill for preloading fonts. Defaults to browserslist's default query: https://github.com/browserslist/browserslist#best-practices",
-        "Override your projects browserslist configuration to specify which browsers to support. Controls font formats and polyfill. Defaults to browserslist's default query if your project has no browserslist configuration"
+        "Override your projects browserslist configuration to specify which browsers to support. Controls font formats and polyfill. Defaults to browserslist's default query if your project has no browserslist configuration",
       type: 'string',
       demand: false,
     })

--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -26,6 +26,12 @@ module.exports = function parseCommandLineOptions(argv) {
       type: 'string',
       demand: false,
     })
+    .options('browsers', {
+      describe:
+        "Specify which browsers to support. Controls which font formats to provide, and whether to apply a JavaScript-based polyfill for preloading fonts. Defaults to browserslist's default query: https://github.com/browserslist/browserslist#best-practices",
+      type: 'string',
+      demand: false,
+    })
     .options('fallbacks', {
       describe:
         'Include fallbacks so the original font will be loaded when dynamic content gets injected at runtime. Disable with --no-fallbacks',
@@ -62,9 +68,9 @@ module.exports = function parseCommandLineOptions(argv) {
       choices: ['auto', 'block', 'swap', 'fallback', 'optional'],
     })
     .options('formats', {
-      describe: 'Font formats to use when subsetting.',
+      describe:
+        'Font formats to use when subsetting. The default is to select the formats based on the browser capabilities as specified via --browsers or the browserslist configuration.',
       type: 'array',
-      default: ['woff2', 'woff'],
       choices: ['woff2', 'woff', 'truetype'],
     })
     .options('subset-per-page', {

--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -29,6 +29,7 @@ module.exports = function parseCommandLineOptions(argv) {
     .options('browsers', {
       describe:
         "Specify which browsers to support. Controls which font formats to provide, and whether to apply a JavaScript-based polyfill for preloading fonts. Defaults to browserslist's default query: https://github.com/browserslist/browserslist#best-practices",
+        "Override your projects browserslist configuration to specify which browsers to support. Controls font formats and polyfill. Defaults to browserslist's default query if your project has no browserslist configuration"
       type: 'string',
       demand: false,
     })

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -33,11 +33,9 @@ module.exports = async function subfont(
   let selectedBrowsers;
   if (browsers) {
     selectedBrowsers = browsersList(browsers);
-  } else if (browsersList.findConfig('.')) {
-    selectedBrowsers = browsersList();
   } else {
-    // Default to all browsers
-    selectedBrowsers = browsersList('defaults');
+    // Will either pick up the browserslist config or use the defaults query
+    selectedBrowsers = browsersList();
   }
 
   if (!formats) {

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -1,5 +1,6 @@
 const AssetGraph = require('assetgraph');
 const prettyBytes = require('pretty-bytes');
+const browsersList = require('browserslist');
 const _ = require('lodash');
 const urlTools = require('urltools');
 const util = require('util');
@@ -16,7 +17,7 @@ module.exports = async function subfont(
     inlineFonts = false,
     inlineCss = false,
     fontDisplay = 'swap',
-    formats = ['woff2', 'woff'],
+    formats,
     subsetPerPage = false,
     inPlace = false,
     inputFiles = [],
@@ -24,9 +25,40 @@ module.exports = async function subfont(
     fallbacks = true,
     dynamic = false,
     harfbuzz = false,
+    browsers,
   },
   console
 ) {
+  let selectedBrowsers;
+  if (browsers) {
+    selectedBrowsers = browsersList(browsers);
+  } else if (browsersList.findConfig('.')) {
+    selectedBrowsers = browsersList();
+  } else {
+    // Default to all browsers
+    selectedBrowsers = browsersList('defaults');
+  }
+
+  if (!formats) {
+    formats = ['woff2'];
+    if (
+      _.intersection(
+        browsersList('supports woff, not supports woff2'),
+        selectedBrowsers
+      ).length > 0
+    ) {
+      formats.push('woff');
+    }
+    if (
+      _.intersection(
+        browsersList('supports ttf, not supports woff'),
+        selectedBrowsers
+      ).length > 0
+    ) {
+      formats.push('truetype');
+    }
+  }
+
   let rootUrl = root && urlTools.urlOrFsPathToUrl(root, true);
   const outRoot = output && urlTools.urlOrFsPathToUrl(output, true);
   let inputUrls;

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -18,6 +18,7 @@ module.exports = async function subfont(
     inlineCss = false,
     fontDisplay = 'swap',
     formats,
+    jsPreload,
     subsetPerPage = false,
     inPlace = false,
     inputFiles = [],
@@ -57,6 +58,14 @@ module.exports = async function subfont(
     ) {
       formats.push('truetype');
     }
+  }
+
+  if (jsPreload === undefined) {
+    jsPreload =
+      _.intersection(
+        browsersList('supports font-loading, not supports link-rel-preload'),
+        selectedBrowsers
+      ).length > 0;
   }
 
   let rootUrl = root && urlTools.urlOrFsPathToUrl(root, true);
@@ -217,6 +226,7 @@ module.exports = async function subfont(
     fontDisplay,
     subsetPerPage,
     formats,
+    jsPreload,
     omitFallbacks: !fallbacks,
     harfbuzz,
     dynamic,

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -18,7 +18,6 @@ module.exports = async function subfont(
     inlineCss = false,
     fontDisplay = 'swap',
     formats,
-    jsPreload,
     subsetPerPage = false,
     inPlace = false,
     inputFiles = [],
@@ -58,13 +57,11 @@ module.exports = async function subfont(
     }
   }
 
-  if (jsPreload === undefined) {
-    jsPreload =
-      _.intersection(
-        browsersList('supports font-loading, not supports link-rel-preload'),
-        selectedBrowsers
-      ).length > 0;
-  }
+  const jsPreload =
+    _.intersection(
+      browsersList('supports font-loading, not supports link-rel-preload'),
+      selectedBrowsers
+    ).length > 0;
 
   let rootUrl = root && urlTools.urlOrFsPathToUrl(root, true);
   const outRoot = output && urlTools.urlOrFsPathToUrl(output, true);

--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -647,6 +647,7 @@ async function subsetFonts(
   {
     formats = ['woff2', 'woff'],
     subsetPath = 'subfont/',
+    jsPreload = true,
     omitFallbacks = false,
     subsetPerPage,
     inlineFonts,
@@ -1041,65 +1042,67 @@ These glyphs are used on your site, but they don't exist in the font you applied
         }
       );
 
-      // Generate JS fallback for browser that don't support <link rel="preload">
-      const preloadData = unsubsettedFontUsagesToPreload.map(
-        (fontUsage, idx) => {
-          const preloadRelation = preloadRelations[idx];
+      if (jsPreload) {
+        // Generate JS fallback for browser that don't support <link rel="preload">
+        const preloadData = unsubsettedFontUsagesToPreload.map(
+          (fontUsage, idx) => {
+            const preloadRelation = preloadRelations[idx];
 
-          const formatMap = {
-            '.woff': 'woff',
-            '.woff2': 'woff2',
-            '.ttf': 'truetype',
-            '.svg': 'svg',
-            '.eot': 'embedded-opentype',
-          };
-          const name = fontUsage.props['font-family'];
-          const props = Object.keys(initialValueByProp).reduce(
-            (result, prop) => {
-              if (
-                fontUsage.props[prop] !==
-                normalizeFontPropertyValue(prop, initialValueByProp[prop])
-              ) {
-                result[prop] = fontUsage.props[prop];
-              }
-              return result;
-            },
-            {}
-          );
+            const formatMap = {
+              '.woff': 'woff',
+              '.woff2': 'woff2',
+              '.ttf': 'truetype',
+              '.svg': 'svg',
+              '.eot': 'embedded-opentype',
+            };
+            const name = fontUsage.props['font-family'];
+            const props = Object.keys(initialValueByProp).reduce(
+              (result, prop) => {
+                if (
+                  fontUsage.props[prop] !==
+                  normalizeFontPropertyValue(prop, initialValueByProp[prop])
+                ) {
+                  result[prop] = fontUsage.props[prop];
+                }
+                return result;
+              },
+              {}
+            );
 
-          return `new FontFace(
+            return `new FontFace(
             "${name}",
             "url('" + "${preloadRelation.href}".toString('url') + "') format('${
-            formatMap[preloadRelation.to.extension]
-          }')",
+              formatMap[preloadRelation.to.extension]
+            }')",
             ${JSON.stringify(props)}
           ).load().then(void 0, function () {});`;
-        }
-      );
+          }
+        );
 
-      const originalFontJsPreloadAsset = htmlAsset.addRelation(
-        {
-          type: 'HtmlScript',
-          hrefType: 'inline',
-          to: {
-            type: 'JavaScript',
-            text: `try{${preloadData.join('')}}catch(e){}`,
+        const originalFontJsPreloadAsset = htmlAsset.addRelation(
+          {
+            type: 'HtmlScript',
+            hrefType: 'inline',
+            to: {
+              type: 'JavaScript',
+              text: `try{${preloadData.join('')}}catch(e){}`,
+            },
           },
-        },
-        'before',
-        insertionPoint
-      ).to;
+          'before',
+          insertionPoint
+        ).to;
 
-      for (const [
-        idx,
-        relation,
-      ] of originalFontJsPreloadAsset.outgoingRelations.entries()) {
-        relation.hrefType = 'rootRelative';
-        relation.to = preloadRelations[idx].to;
-        relation.refreshHref();
+        for (const [
+          idx,
+          relation,
+        ] of originalFontJsPreloadAsset.outgoingRelations.entries()) {
+          relation.hrefType = 'rootRelative';
+          relation.to = preloadRelations[idx].to;
+          relation.refreshHref();
+        }
+
+        originalFontJsPreloadAsset.minify();
       }
-
-      originalFontJsPreloadAsset.minify();
     }
 
     if (subsetFontUsages.length === 0) {
@@ -1238,7 +1241,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
     );
 
     let cssAssetInsertion = cssRelation;
-    if (!inlineFonts) {
+    if (jsPreload && !inlineFonts) {
       // JS-based font preloading for browsers without <link rel="preload"> support
       const fontFaceContructorCalls = [];
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@gustavnikolaj/async-main-wrap": "^3.0.1",
     "assetgraph": "^6.1.1",
+    "browserslist": "^4.13.0",
     "css-font-parser": "^0.3.0",
     "css-font-weight-names": "^0.2.1",
     "css-list-helpers": "^2.0.0",

--- a/test/subfont.js
+++ b/test/subfont.js
@@ -797,7 +797,7 @@ describe('subfont', function () {
 
   describe('configuring via browserslist', function () {
     // https://github.com/browserslist/browserslist#best-practices
-    it('should default to woff+woff2 when no config is given, due to the browserslist defaults', async function () {
+    it('should default to woff+woff2 and jsPreload:true when no config is given, due to the browserslist defaults', async function () {
       const dir = pathModule.resolve(
         __dirname,
         '..',
@@ -825,6 +825,7 @@ describe('subfont', function () {
         expect(mockSubsetFonts, 'to have calls satisfying', () => {
           mockSubsetFonts(expect.it('to be an object'), {
             formats: ['woff2', 'woff'],
+            jsPreload: true,
           });
         });
       } finally {
@@ -861,6 +862,7 @@ describe('subfont', function () {
         expect(mockSubsetFonts, 'to have calls satisfying', () => {
           mockSubsetFonts(expect.it('to be an object'), {
             formats: ['woff2', 'woff'],
+            jsPreload: false,
           });
         });
       } finally {
@@ -896,6 +898,7 @@ describe('subfont', function () {
         expect(mockSubsetFonts, 'to have calls satisfying', () => {
           mockSubsetFonts(expect.it('to be an object'), {
             formats: ['woff2', 'truetype'],
+            jsPreload: true,
           });
         });
       } finally {

--- a/test/subsetFonts.js
+++ b/test/subsetFonts.js
@@ -2856,6 +2856,29 @@ describe('subsetFonts', function () {
       expect(warnings, 'to satisfy', []);
     });
 
+    describe('with jsPreload:false', function () {
+      it('should not add the JavaScript-based preload "polyfill"', async function () {
+        const assetGraph = new AssetGraph({
+          root: pathModule.resolve(
+            __dirname,
+            //            '../testdata/subsetFonts/local-single/'
+            '../testdata/subsetFonts/unused-variant/'
+          ),
+        });
+        const [htmlAsset] = await assetGraph.loadAssets('index.html');
+        await assetGraph.populate({
+          followRelations: {
+            crossorigin: false,
+          },
+        });
+        await subsetFonts(assetGraph, {
+          jsPreload: false,
+        });
+
+        expect(htmlAsset.text, 'not to contain', 'new FontFace');
+      });
+    });
+
     it('should error out on multiple @font-face declarations with the same family/weight/style/stretch', async function () {
       httpception();
 

--- a/testdata/browserslistInPackageJson/index.html
+++ b/testdata/browserslistInPackageJson/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html></html>

--- a/testdata/browserslistInPackageJson/package.json
+++ b/testdata/browserslistInPackageJson/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": ["Chrome >= 36", "Safari 5"]
+}


### PR DESCRIPTION
Fixes #119

The current set of default browsers happens to result in `woff`+`woff2` and the JS preload polyfill being selected atm., which is luckily the same as our current `--formats` default :tada:

TODO:

- [x] Also wire it up to control whether the JavaScript-based preload polyfill is included.