### PR TITLE
Respect silent:true wrt. the console output

### DIFF
--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -29,10 +29,16 @@ module.exports = async function subfont(
   },
   console
 ) {
-  function log(message) {
+  function logToConsole(severity, ...args) {
     if (!silent && console) {
-      console.log(message);
+      console[severity](...args);
     }
+  }
+  function log(...args) {
+    logToConsole('log', ...args);
+  }
+  function warn(...args) {
+    logToConsole('warn', ...args);
   }
 
   let selectedBrowsers;
@@ -81,7 +87,7 @@ module.exports = async function subfont(
 
       if (rootUrl) {
         if (rootUrl.startsWith('file:')) {
-          console.warn(`Guessing --root from input files: ${rootUrl}`);
+          warn(`Guessing --root from input files: ${rootUrl}`);
         } else {
           rootUrl = urlTools.ensureTrailingSlash(rootUrl);
         }
@@ -89,7 +95,7 @@ module.exports = async function subfont(
     }
   } else if (rootUrl && rootUrl.startsWith('file:')) {
     inputUrls = [`${rootUrl}**/*.html`];
-    console.warn(`No input files specified, defaulting to ${inputUrls[0]}`);
+    warn(`No input files specified, defaulting to ${inputUrls[0]}`);
   } else {
     throw new SyntaxError(
       "No input files and no --root specified (or it isn't file:), cannot proceed.\n"

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -29,6 +29,12 @@ module.exports = async function subfont(
   },
   console
 ) {
+  function log(message) {
+    if (!silent && console) {
+      console.log(message);
+    }
+  }
+
   let selectedBrowsers;
   if (browsers) {
     selectedBrowsers = browsersList(browsers);
@@ -319,7 +325,7 @@ module.exports = async function subfont(
   }
 
   if (debug) {
-    console.log(util.inspect(fontInfo, false, 99));
+    log(util.inspect(fontInfo, false, 99));
   }
 
   let totalSavings = sumSizesBefore - sumSizesAfter;
@@ -345,7 +351,7 @@ module.exports = async function subfont(
       (fontUsage) => fontUsage.props['font-family']
     );
     const numFonts = Object.keys(fontUsagesByFontFamily).length;
-    console.log(
+    log(
       `${htmlAsset}: ${numFonts} font${numFonts === 1 ? '' : 's'} (${
         fontUsages.length
       } variant${fontUsages.length === 1 ? '' : 's'}) in use, ${prettyBytes(
@@ -353,7 +359,7 @@ module.exports = async function subfont(
       )} total. Created subsets: ${prettyBytes(sumSmallestSubsetSize)} total`
     );
     for (const fontFamily of Object.keys(fontUsagesByFontFamily).sort()) {
-      console.log(`  ${fontFamily}:`);
+      log(`  ${fontFamily}:`);
       for (const fontUsage of fontUsagesByFontFamily[fontFamily]) {
         const variantShortName = `${fontUsage.props['font-weight']}${
           fontUsage.props['font-style'] === 'italic' ? 'i' : ' '
@@ -383,17 +389,16 @@ module.exports = async function subfont(
         } else {
           status += ', no subset font created';
         }
-        console.log(status);
+        log(status);
       }
     }
   }
-  console.log(
+  log(
     `HTML/JS/CSS size increase: ${prettyBytes(sumSizesAfter - sumSizesBefore)}`
   );
-  console.log(`Total savings: ${prettyBytes(totalSavings)}`);
+  log(`Total savings: ${prettyBytes(totalSavings)}`);
   if (!dryRun) {
-    console.log('Output written to', outRoot || assetGraph.root);
+    log('Output written to', outRoot || assetGraph.root);
   }
-
   return assetGraph;
 };

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -167,10 +167,9 @@ module.exports = async function subfont(
 
   if (silent) {
     // Avoid failing on assetGraph.warn
-    // It would be better if logEvents supported a custom console implementation
     assetGraph.on('warn', () => {});
   } else {
-    await assetGraph.logEvents();
+    await assetGraph.logEvents({ console });
   }
 
   await assetGraph.loadAssets(inputUrls);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/Munter/subfont#readme",
   "dependencies": {
     "@gustavnikolaj/async-main-wrap": "^3.0.1",
-    "assetgraph": "^6.1.1",
+    "assetgraph": "^6.2.0",
     "browserslist": "^4.13.0",
     "css-font-parser": "^0.3.0",
     "css-font-weight-names": "^0.2.1",

--- a/test/subfont.js
+++ b/test/subfont.js
@@ -19,7 +19,12 @@ const openSansBold = require('fs').readFileSync(
 describe('subfont', function () {
   let mockConsole;
   beforeEach(async function () {
-    mockConsole = { log: sinon.spy(), warn: sinon.spy(), error: sinon.spy() };
+    mockConsole = {
+      info: sinon.spy(),
+      log: sinon.spy(),
+      warn: sinon.spy(),
+      error: sinon.spy(),
+    };
   });
 
   afterEach(function () {
@@ -75,7 +80,6 @@ describe('subfont', function () {
         {
           root,
           inputFiles: [`${root}/index.html`],
-          silent: true,
           dryRun: true,
         },
         mockConsole
@@ -137,7 +141,6 @@ describe('subfont', function () {
         {
           root,
           inputFiles: [`${root}/index.html`],
-          silent: true,
           dryRun: true,
         },
         mockConsole
@@ -200,7 +203,6 @@ describe('subfont', function () {
           root,
           inputFiles: [root],
           fallbacks: false,
-          silent: true,
           dryRun: true,
         },
         mockConsole
@@ -280,7 +282,6 @@ describe('subfont', function () {
             root,
             inputFiles: [root],
             fallbacks: false,
-            silent: true,
             dryRun: true,
           },
           mockConsole
@@ -314,7 +315,6 @@ describe('subfont', function () {
             root,
             inputFiles: [root],
             fallbacks: false,
-            silent: true,
             dryRun: true,
           },
           mockConsole
@@ -400,7 +400,6 @@ describe('subfont', function () {
             root,
             inputFiles: [root, `${root}page2`],
             fallbacks: false,
-            silent: true,
             dryRun: true,
           },
           mockConsole
@@ -446,7 +445,6 @@ describe('subfont', function () {
       await subfont(
         {
           subsetPerPage: false,
-          silent: true,
           dryRun: true,
           root,
           inputFiles: [`${root}/first.html`, `${root}/second.html`],
@@ -483,7 +481,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           root,
           inputFiles: [`${root}/first.html`, `${root}/second.html`],
@@ -507,7 +504,6 @@ describe('subfont', function () {
       await subfont(
         {
           subsetPerPage: true,
-          silent: true,
           dryRun: true,
           root,
           inputFiles: [`${root}/first.html`, `${root}/second.html`],
@@ -539,7 +535,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           dynamic: true,
           debug: true,
@@ -567,7 +562,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           dynamic: true,
           debug: true,
@@ -595,7 +589,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           dynamic: true,
           debug: true,
@@ -624,7 +617,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           dynamic: true,
           debug: true,
@@ -653,7 +645,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           dynamic: true,
           debug: true,
@@ -687,7 +678,6 @@ describe('subfont', function () {
 
       await subfont(
         {
-          silent: true,
           dryRun: true,
           dynamic: true,
           debug: true,
@@ -737,7 +727,6 @@ describe('subfont', function () {
 
       const assetGraph = await subfont(
         {
-          silent: true,
           dryRun: true,
           debug: true,
           canonicalRoot: 'https://www.netlify.com/',
@@ -779,7 +768,6 @@ describe('subfont', function () {
         {
           root,
           inputFiles: [`${root}/index.html`],
-          silent: true,
           dryRun: true,
         },
         mockConsole
@@ -817,7 +805,6 @@ describe('subfont', function () {
           {
             root,
             inputFiles: [`${root}/index.html`],
-            silent: true,
             dryRun: true,
           },
           mockConsole
@@ -853,7 +840,6 @@ describe('subfont', function () {
           {
             root,
             inputFiles: [`${root}/index.html`],
-            silent: true,
             dryRun: true,
             browsers: 'IE 11, Chrome 80',
           },
@@ -890,7 +876,6 @@ describe('subfont', function () {
           {
             root,
             inputFiles: [`${root}/index.html`],
-            silent: true,
             dryRun: true,
           },
           mockConsole


### PR DESCRIPTION
Instead of `silent` only controlling whether `logEvents` gets used.
Also, don't break if no console object gets handed in.

I encountered this while writing up https://github.com/Munter/subfont/issues/122#issuecomment-670870698