### PR TITLE
Support subfont --formats foo,bar and fix weirdness with --formats consuming further non-option arguments

### DIFF
--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 module.exports = function parseCommandLineOptions(argv) {
   let yargs = require('yargs');
   if (argv) {
@@ -35,8 +37,14 @@ module.exports = function parseCommandLineOptions(argv) {
     .options('formats', {
       describe:
         'Font formats to use when subsetting. The default is to select the formats based on the browser capabilities as specified via --browsers or the browserslist configuration.',
-      type: 'array',
+      type: 'string', // type: 'array' is weird: https://github.com/yargs/yargs/issues/846
       choices: ['woff2', 'woff', 'truetype'],
+      coerce(formats) {
+        // Make sure we support comma-separated syntax: --format truetype,woff
+        return _.flatten(
+          _.flatten([formats]).map((format) => format.split(','))
+        );
+      },
     })
     .options('fallbacks', {
       describe:

--- a/test/parseCommandLineOptions.js
+++ b/test/parseCommandLineOptions.js
@@ -30,4 +30,22 @@ describe('parseCommandLineOptions', function () {
       }
     );
   });
+
+  it('should allow repeating --formats', function () {
+    expect(
+      parseCommandLineOptions(['--formats', 'truetype', '--formats', 'woff2']),
+      'to satisfy',
+      {
+        formats: ['truetype', 'woff2'],
+      }
+    );
+  });
+
+  it('should allow passing a comma-separated list of formats', function () {
+    const options = parseCommandLineOptions(['--formats', 'truetype,woff2']);
+
+    expect(options, 'to satisfy', {
+      formats: ['truetype', 'woff2'],
+    });
+  });
 });


### PR DESCRIPTION
I was kinda surprised that `subfont --format woff,woff2` didn't work. Turns out yargs doesn't support that even though the option is declared as `array`: https://github.com/yargs/yargs/issues/846

Also, the `array` type is [weird](https://github.com/yargs/yargs/issues/162), so I found that `subfont --formats woff2 path/to/page.html` fails because yargs tries to consume `path/to/page.html` as another format :zany_face:

This PR fixes both issues by switching to `string` and coercing the result into an array.