### PR TITLE
Remove the JavaScript-based preload polyfill

### DIFF
--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -67,12 +67,6 @@ module.exports = async function subfont(
     }
   }
 
-  const jsPreload =
-    _.intersection(
-      browsersList('supports font-loading, not supports link-rel-preload'),
-      selectedBrowsers
-    ).length > 0;
-
   let rootUrl = root && urlTools.urlOrFsPathToUrl(root, true);
   const outRoot = output && urlTools.urlOrFsPathToUrl(output, true);
   let inputUrls;
@@ -228,7 +222,6 @@ module.exports = async function subfont(
     inlineCss,
     fontDisplay,
     formats,
-    jsPreload,
     omitFallbacks: !fallbacks,
     hrefType: relativeUrls ? 'relative' : 'rootRelative',
     dynamic,

--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -461,28 +461,6 @@ function md5HexPrefix(stringOrBuffer) {
     .slice(0, 10);
 }
 
-// Helper for turning an array of string/url tokens into a valid JavaScript expression string
-function stringifyTokens(tokens) {
-  let expressionStr = '';
-  for (let i = 0; i < tokens.length; i += 1) {
-    if (i > 0) {
-      expressionStr += '+';
-    }
-    const token = tokens[i];
-    if (token.type === 'url') {
-      expressionStr += `'${token.value}'.toString('url')`;
-    } else if (token.type === 'string') {
-      let str = token.value;
-      while (i + 1 < tokens.length && tokens[i + 1].type === 'string') {
-        i += 1;
-        str += tokens[i].value;
-      }
-      expressionStr += `"${str.replace(/"/g, '\\"')}"`;
-    }
-  }
-  return expressionStr;
-}
-
 async function createSelfHostedGoogleFontsCssAsset(
   assetGraph,
   googleFontsCssAsset,
@@ -563,7 +541,6 @@ async function subsetFonts(
   {
     formats = ['woff2', 'woff'],
     subsetPath = 'subfont/',
-    jsPreload = true,
     omitFallbacks = false,
     inlineCss,
     fontDisplay,
@@ -934,83 +911,19 @@ These glyphs are used on your site, but they don't exist in the font you applied
 
     if (unsubsettedFontUsagesToPreload.length > 0) {
       // Insert <link rel="preload">
-      const preloadRelations = unsubsettedFontUsagesToPreload.map(
-        (fontUsage) => {
-          // Always preload unsubsetted font files, they might be any format, so can't be clever here
-          return htmlAsset.addRelation(
-            {
-              type: 'HtmlPreloadLink',
-              hrefType,
-              to: fontUsage.fontUrl,
-              as: 'font',
-            },
-            'before',
-            insertionPoint
-          );
-        }
-      );
-
-      if (jsPreload) {
-        // Generate JS fallback for browser that don't support <link rel="preload">
-        const preloadData = unsubsettedFontUsagesToPreload.map(
-          (fontUsage, idx) => {
-            const preloadRelation = preloadRelations[idx];
-
-            const formatMap = {
-              '.woff': 'woff',
-              '.woff2': 'woff2',
-              '.ttf': 'truetype',
-              '.svg': 'svg',
-              '.eot': 'embedded-opentype',
-            };
-            const name = fontUsage.props['font-family'];
-            const props = Object.keys(initialValueByProp).reduce(
-              (result, prop) => {
-                if (
-                  fontUsage.props[prop] !==
-                  normalizeFontPropertyValue(prop, initialValueByProp[prop])
-                ) {
-                  result[prop] = fontUsage.props[prop];
-                }
-                return result;
-              },
-              {}
-            );
-
-            return `new FontFace(
-            "${name}",
-            "url('" + "${preloadRelation.href}".toString('url') + "') format('${
-              formatMap[preloadRelation.to.extension]
-            }')",
-            ${JSON.stringify(props)}
-          ).load().then(void 0, function () {});`;
-          }
-        );
-
-        const originalFontJsPreloadAsset = htmlAsset.addRelation(
+      unsubsettedFontUsagesToPreload.map((fontUsage) => {
+        // Always preload unsubsetted font files, they might be any format, so can't be clever here
+        return htmlAsset.addRelation(
           {
-            type: 'HtmlScript',
-            hrefType: 'inline',
-            to: {
-              type: 'JavaScript',
-              text: `try{${preloadData.join('')}}catch(e){}`,
-            },
+            type: 'HtmlPreloadLink',
+            hrefType,
+            to: fontUsage.fontUrl,
+            as: 'font',
           },
           'before',
           insertionPoint
-        ).to;
-
-        for (const [
-          idx,
-          relation,
-        ] of originalFontJsPreloadAsset.outgoingRelations.entries()) {
-          relation.hrefType = hrefType;
-          relation.to = preloadRelations[idx].to;
-          relation.refreshHref();
-        }
-
-        originalFontJsPreloadAsset.minify();
-      }
+        );
+      });
     }
 
     if (subsetFontUsages.length === 0) {
@@ -1162,107 +1075,6 @@ These glyphs are used on your site, but they don't exist in the font you applied
       insertionPoint
     );
 
-    let cssAssetInsertion = cssRelation;
-    if (jsPreload) {
-      // JS-based font preloading for browsers without <link rel="preload"> support
-      const fontFaceContructorCalls = [];
-
-      cssAsset.parseTree.walkAtRules('font-face', (rule) => {
-        let name;
-        const tokens = [];
-        const props = {};
-
-        rule.walkDecls(({ prop, value }) => {
-          const propName = prop.toLowerCase();
-          if (propName === 'font-weight') {
-            value = value
-              .split(/\s+/)
-              .map((token) => normalizeFontPropertyValue('font-weight', token))
-              .join(' ');
-            if (/^\d+$/.test(value)) {
-              value = parseInt(value, 10);
-            }
-          }
-
-          if (propName in initialValueByProp) {
-            if (
-              normalizeFontPropertyValue(propName, value) !==
-              normalizeFontPropertyValue(propName, initialValueByProp[propName])
-            ) {
-              props[propName] = value;
-            }
-          }
-
-          if (propName === 'font-family') {
-            name = fontFamily.parse(value)[0];
-          } else if (propName === 'src') {
-            for (const relation of cssAsset.outgoingRelations) {
-              if (
-                relation.node === rule &&
-                relation.hrefType !== 'inline' &&
-                relation.to.path.startsWith('/subfont/') && // Avoid preloading unused variants
-                fontFormatByContentType[relation.to.contentType]
-              ) {
-                if (tokens.length > 0) {
-                  tokens.push({ type: 'string', value: ',' });
-                }
-                tokens.push(
-                  { type: 'string', value: "url('" },
-                  {
-                    type: 'url',
-                    value: htmlAsset.assetGraph.buildHref(
-                      relation.to.url,
-                      htmlAsset.url,
-                      { hrefType }
-                    ),
-                  },
-                  {
-                    type: 'string',
-                    value: `') format('${
-                      fontFormatByContentType[relation.to.contentType]
-                    }')`,
-                  }
-                );
-              }
-            }
-          }
-        });
-
-        if (tokens.length > 0) {
-          const originalFontFamily = name.replace(/__subset$/, '');
-          if (
-            fontUsages.some(
-              (fontUsage) =>
-                fontUsage.fontFamilies.has(originalFontFamily) &&
-                fontUsage.preload
-            )
-          ) {
-            fontFaceContructorCalls.push(
-              `new FontFace("${name}", ${stringifyTokens(
-                tokens
-              )}, ${JSON.stringify(props)}).load();`
-            );
-          }
-        }
-      });
-
-      const jsPreloadRelation = htmlAsset.addRelation(
-        {
-          type: 'HtmlScript',
-          hrefType: 'inline',
-          to: {
-            type: 'JavaScript',
-            text: `try {${fontFaceContructorCalls.join('')}} catch (e) {}`,
-          },
-        },
-        'before',
-        cssRelation
-      );
-
-      jsPreloadRelation.to.minify();
-      cssAssetInsertion = jsPreloadRelation;
-    }
-
     if (!omitFallbacks && inlineCss && unusedVariantsCss) {
       // The fallback CSS for unused variants needs to go into its own stylesheet after the crude version of the JS-based preload "polyfill"
       const cssAsset = htmlAsset.addRelation(
@@ -1274,7 +1086,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
           },
         },
         'after',
-        cssAssetInsertion
+        cssRelation
       ).to;
       for (const relation of cssAsset.outgoingRelations) {
         relation.hrefType = hrefType;

--- a/test/subfont.js
+++ b/test/subfont.js
@@ -652,64 +652,9 @@ describe('subfont', function () {
     });
   });
 
-  describe('with a canonical root and loading the page from a remote server', function () {
-    // Regression test for https://gitter.im/assetgraph/assetgraph?at=5ece5da89da05a060a3417fc
-    it('should refer to the fallback CSS with a root-relative url', async function () {
-      httpception([
-        {
-          request: 'GET https://www.netlify.com/index.html',
-          response: {
-            headers: {
-              'Content-Type': 'text/html',
-            },
-            body: `<!DOCTYPE html>
-            <html>
-              <head>
-                <style>
-                  @font-face{font-family: Open Sans; src:url(OpenSans.woff) format("woff")}
-                </style>
-              </head>
-              <body>
-                <div style="font-family: Open Sans">Hello</div>
-              </body>
-            </html>
-          `,
-          },
-        },
-        {
-          request: 'GET https://www.netlify.com/OpenSans.woff',
-          response: {
-            headers: {
-              'Content-Type': 'font/woff',
-            },
-            body: openSansBold,
-          },
-        },
-      ]);
-
-      const assetGraph = await subfont(
-        {
-          dryRun: true,
-          debug: true,
-          canonicalRoot: 'https://www.netlify.com/',
-          inputFiles: ['https://www.netlify.com/index.html'],
-        },
-        mockConsole
-      );
-      const [, asyncLoadJavaScriptAsset] = assetGraph.findAssets({
-        type: 'JavaScript',
-      });
-      expect(
-        asyncLoadJavaScriptAsset.text,
-        'to contain',
-        `el.href='/subfont/fallback-`
-      );
-    });
-  });
-
   describe('configuring via browserslist', function () {
     // https://github.com/browserslist/browserslist#best-practices
-    it('should default to woff+woff2 and jsPreload:true when no config is given, due to the browserslist defaults', async function () {
+    it('should default to woff+woff2 when no config is given, due to the browserslist defaults', async function () {
       const dir = pathModule.resolve(
         __dirname,
         '..',
@@ -736,7 +681,6 @@ describe('subfont', function () {
         expect(mockSubsetFonts, 'to have calls satisfying', () => {
           mockSubsetFonts(expect.it('to be an object'), {
             formats: ['woff2', 'woff'],
-            jsPreload: true,
           });
         });
       } finally {
@@ -772,7 +716,6 @@ describe('subfont', function () {
         expect(mockSubsetFonts, 'to have calls satisfying', () => {
           mockSubsetFonts(expect.it('to be an object'), {
             formats: ['woff2', 'woff'],
-            jsPreload: false,
           });
         });
       } finally {
@@ -807,7 +750,6 @@ describe('subfont', function () {
         expect(mockSubsetFonts, 'to have calls satisfying', () => {
           mockSubsetFonts(expect.it('to be an object'), {
             formats: ['woff2', 'truetype'],
-            jsPreload: true,
           });
         });
       } finally {

--- a/test/subsetFonts.js
+++ b/test/subsetFonts.js
@@ -148,32 +148,6 @@ describe('subsetFonts', function () {
         as: 'font',
       },
       {
-        type: 'HtmlScript',
-        to: {
-          isInline: true,
-          text: expect.it('to contain', 'Open Sans__subset'),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
-      },
-      {
         type: 'HtmlStyle',
         hrefType: 'rootRelative',
         href: expect
@@ -361,16 +335,6 @@ describe('subsetFonts', function () {
           as: 'font',
         },
         {
-          type: 'HtmlScript',
-          to: {
-            type: 'JavaScript',
-            isInline: true,
-            text: expect
-              .it('to contain', `new FontFace('Open Sans__subset',"url('`)
-              .and('to contain', '__subset'),
-          },
-        },
-        {
           type: 'HtmlStyle',
           href: undefined,
           to: {
@@ -473,33 +437,6 @@ describe('subsetFonts', function () {
           isLoaded: true,
         },
         as: 'font',
-      },
-      {
-        type: 'HtmlScript',
-        to: {
-          isInline: true,
-          text: expect.it('to contain', 'Open Sans__subset'),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Open_Sans-400-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
       },
       {
         type: 'HtmlStyle',
@@ -914,7 +851,6 @@ describe('subsetFonts', function () {
 
       expect(assetGraph, 'to contain relation', 'CssImport');
       expect(assetGraph, 'to contain relations', 'HtmlStyle', 3);
-      expect(assetGraph, 'to contain relations', 'JavaScriptStaticUrl', 3);
     });
 
     it('should not break for two CSS @imports in different stylesheets', async function () {
@@ -934,7 +870,6 @@ describe('subsetFonts', function () {
 
       expect(assetGraph, 'to contain relation', 'CssImport');
       expect(assetGraph, 'to contain relations', 'HtmlStyle', 4);
-      expect(assetGraph, 'to contain relations', 'JavaScriptStaticUrl', 3);
     });
   });
 
@@ -995,80 +930,6 @@ describe('subsetFonts', function () {
           isLoaded: true,
         },
         as: 'font',
-      },
-      {
-        type: 'HtmlScript',
-        to: {
-          isInline: true,
-          text: expect
-            .it('to contain', 'Jim Nightshade__subset')
-            .and('to contain', 'Montserrat__subset')
-            .and('to contain', 'Space Mono__subset'),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Jim_Nightshade-400-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Montserrat-400-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Space_Mono-400-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
       },
       {
         type: 'HtmlStyle',
@@ -1238,80 +1099,6 @@ describe('subsetFonts', function () {
         as: 'font',
       },
       {
-        type: 'HtmlScript',
-        to: {
-          isInline: true,
-          text: expect
-            .it('to contain', 'Roboto__subset')
-            .and('to contain', "'font-weight':500")
-            .and('to contain', "'font-style':'italic','font-weight':300"),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Roboto-500-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Roboto-400-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: /^\/subfont\/Roboto-300i-[a-f0-9]{10}\.woff2$/,
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
-      },
-      {
         type: 'HtmlStyle',
         href: expect
           .it('to begin with', '/subfont/fonts-')
@@ -1451,35 +1238,6 @@ describe('subsetFonts', function () {
           as: 'font',
         },
         {
-          type: 'HtmlScript',
-          to: {
-            isInline: true,
-            text: expect.it('to contain', 'Open Sans__subset'),
-            outgoingRelations: [
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'rootRelative',
-                href: /^\/subfont\/Open_Sans-400-[a-f0-9]{10}\.woff2$/,
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff2',
-                  extension: '.woff2',
-                },
-              },
-
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'rootRelative',
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff',
-                  extension: '.woff',
-                },
-              },
-            ],
-          },
-        },
-        {
           type: 'HtmlStyle',
           href: expect
             .it('to begin with', '/subfont/fonts-')
@@ -1541,32 +1299,6 @@ describe('subsetFonts', function () {
           href: /^\/subfont\/Open_Sans-400-[a-f0-9]{10}\.woff2$/,
           to: sharedFont,
           as: 'font',
-        },
-        {
-          type: 'HtmlScript',
-          to: {
-            type: 'JavaScript',
-            isInline: true,
-            text: expect.it('to contain', 'Open Sans__subset'),
-            outgoingRelations: [
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'rootRelative',
-                href: /^\/subfont\/Open_Sans-400-[a-f0-9]{10}\.woff2$/,
-                to: sharedFont,
-              },
-
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'rootRelative',
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff',
-                  extension: '.woff',
-                },
-              },
-            ],
-          },
         },
         {
           type: 'HtmlStyle',
@@ -1632,25 +1364,6 @@ describe('subsetFonts', function () {
       ]);
       await assetGraph.populate();
       await subsetFonts(assetGraph);
-      const firstJavaScriptPreloadPolyfill = assetGraph.findRelations({
-        from: firstHtmlAsset,
-        type: 'HtmlScript',
-      })[0].to;
-      expect(
-        firstJavaScriptPreloadPolyfill.text,
-        'to contain',
-        "new FontFace('font1__subset'"
-      ).and('not to contain', "new FontFace('font2__subset'");
-
-      const secondJavaScriptPreloadPolyfill = assetGraph.findRelations({
-        from: secondHtmlAsset,
-        type: 'HtmlScript',
-      })[0].to;
-      expect(
-        secondJavaScriptPreloadPolyfill.text,
-        'to contain',
-        "new FontFace('font2__subset'"
-      ).and('not to contain', "new FontFace('font1__subset'");
       expect(
         assetGraph.findRelations({
           from: firstHtmlAsset,
@@ -1980,22 +1693,6 @@ describe('subsetFonts', function () {
         contentType: 'font/ttf',
       },
       {
-        type: 'HtmlScript',
-        to: {
-          type: 'JavaScript',
-          isInline: true,
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              href: '/OpenSans.ttf',
-              to: {
-                isLoaded: true,
-              },
-            },
-          ],
-        },
-      },
-      {
         type: 'HtmlStyle',
         to: {
           isLoaded: true,
@@ -2254,40 +1951,6 @@ describe('subsetFonts', function () {
         contentType: 'font/woff2',
       },
       {
-        type: 'HtmlScript',
-        to: {
-          type: 'JavaScript',
-          isInline: true,
-          text: expect.it('to contain', 'Open Sans__subset'),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: expect
-                .it('to begin with', '/subfont/Open_Sans-400-')
-                .and('to match', /-[0-9a-f]{10}\./)
-                .and('to end with', '.woff2'),
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
-      },
-
-      {
         type: 'HtmlStyle',
         hrefType: 'rootRelative',
         href: expect
@@ -2375,40 +2038,6 @@ describe('subsetFonts', function () {
           contentType: 'font/woff2',
         },
         {
-          type: 'HtmlScript',
-          to: {
-            type: 'JavaScript',
-            isInline: true,
-            text: expect.it('to contain', 'Open Sans__subset'),
-            outgoingRelations: [
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'relative',
-                href: expect
-                  .it('to begin with', 'subfont/Open_Sans-400-')
-                  .and('to match', /-[0-9a-f]{10}\./)
-                  .and('to end with', '.woff2'),
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff2',
-                  extension: '.woff2',
-                },
-              },
-
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'relative',
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff',
-                  extension: '.woff',
-                },
-              },
-            ],
-          },
-        },
-
-        {
           type: 'HtmlStyle',
           hrefType: 'relative',
           href: expect
@@ -2458,51 +2087,6 @@ describe('subsetFonts', function () {
         },
         { type: 'HtmlNoscript', hrefType: 'inline' },
       ]);
-    });
-  });
-
-  it('should add a script that async loads a CSS with the original @font-face declarations right before </body>', async function () {
-    const assetGraph = new AssetGraph({
-      root: pathModule.resolve(
-        __dirname,
-        '../testdata/subsetFonts/local-single/'
-      ),
-    });
-    const [htmlAsset] = await assetGraph.loadAssets('index.html');
-    await assetGraph.populate();
-    await subsetFonts(assetGraph);
-    const originalInlineStylesheet = assetGraph.findAssets({
-      type: 'Css',
-      isInline: true,
-    })[0];
-    // Check that the original @font-face was removed from the inline stylesheet:
-    expect(originalInlineStylesheet.text, 'not to contain', '@font-face');
-    const fallbackCss = assetGraph.findAssets({
-      fileName: { $regex: /^fallback-.*\.css/ },
-    })[0];
-    expect(
-      htmlAsset.text,
-      'to contain',
-      `<script>(function(){var el=document.createElement('link');el.href='/subfont/${fallbackCss.fileName}'.toString('url');el.rel='stylesheet';document.body.appendChild(el)}())</script><noscript><link rel="stylesheet" href="/subfont/${fallbackCss.fileName}"></noscript></body></html>`
-    );
-    expect(
-      fallbackCss.text,
-      'to equal',
-      '@font-face{font-family:Open Sans;font-style:normal;font-weight:400;src:local("Open Sans Regular"),local("OpenSans-Regular"),url(/OpenSans.ttf) format("truetype")}'
-    );
-    const originalFontFaceLoadingScript = assetGraph.findAssets({
-      type: 'JavaScript',
-      isInline: true,
-      text: { $regex: /createElement/ },
-    })[0];
-    expect(
-      originalFontFaceLoadingScript.text,
-      'to contain',
-      `el.href='/subfont/${fallbackCss.fileName}'`
-    );
-    expect(assetGraph, 'to contain relation', {
-      from: originalFontFaceLoadingScript,
-      to: { type: 'Css' },
     });
   });
 
@@ -2651,13 +2235,6 @@ describe('subsetFonts', function () {
         },
       });
       await subsetFonts(assetGraph);
-      const [preloadPolyfill] = assetGraph.findAssets({
-        type: 'JavaScript',
-        text: { $regex: /new FontFace/ },
-      });
-      expect(preloadPolyfill.text, 'to contain', ".woff2'")
-        .and('to contain', 'Input_Mono-400')
-        .and('not to contain', 'Input_Mono-700');
       const preloadLinks = assetGraph.findRelations({
         from: htmlAsset,
         type: 'HtmlPreloadLink',
@@ -2682,14 +2259,6 @@ describe('subsetFonts', function () {
           },
         });
         await subsetFonts(assetGraph);
-        const [preloadPolyfill] = assetGraph.findAssets({
-          type: 'JavaScript',
-          text: { $regex: /new FontFace/ },
-        });
-        expect(preloadPolyfill.text, 'to contain', ".woff2'")
-          .and('to contain', ".woff'")
-          .and('not to contain', ".ttf'")
-          .and('not to contain', 'fonts.gstatic.com');
         const preloadLinks = assetGraph.findRelations({
           from: htmlAsset,
           type: 'HtmlPreloadLink',
@@ -2840,39 +2409,6 @@ describe('subsetFonts', function () {
           isLoaded: true,
         },
         as: 'font',
-      },
-      {
-        type: 'HtmlScript',
-        to: {
-          type: 'JavaScript',
-          isInline: true,
-          text: expect.it('to contain', 'Open Sans__subset'),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: expect
-                .it('to begin with', '/subfont/Open_Sans-400-')
-                .and('to match', /-[0-9a-f]{10}\./)
-                .and('to end with', '.woff2'),
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
       },
       {
         type: 'HtmlStyle',
@@ -3060,71 +2596,6 @@ describe('subsetFonts', function () {
           isLoaded: true,
         },
         as: 'font',
-      },
-      {
-        type: 'HtmlScript',
-        to: {
-          type: 'JavaScript',
-          isInline: true,
-          text: expect.it('to contain', 'Open Sans__subset'),
-          outgoingRelations: [
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: expect
-                .it('to begin with', '/subfont/Local_Sans-400-')
-                .and('to match', /-[0-9a-f]{10}\./)
-                .and('to end with', '.woff2'),
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: expect
-                .it('to begin with', '/subfont/Local_Sans-400-')
-                .and('to match', /-[0-9a-f]{10}\./)
-                .and('to end with', '.woff'),
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: expect
-                .it('to begin with', '/subfont/Open_Sans-400-')
-                .and('to match', /-[0-9a-f]{10}\./)
-                .and('to end with', '.woff2'),
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff2',
-                extension: '.woff2',
-              },
-            },
-
-            {
-              type: 'JavaScriptStaticUrl',
-              hrefType: 'rootRelative',
-              href: expect
-                .it('to begin with', '/subfont/Open_Sans-400-')
-                .and('to match', /-[0-9a-f]{10}\./)
-                .and('to end with', '.woff'),
-              to: {
-                isLoaded: true,
-                contentType: 'font/woff',
-                extension: '.woff',
-              },
-            },
-          ],
-        },
       },
       {
         type: 'HtmlStyle',
@@ -3321,14 +2792,6 @@ describe('subsetFonts', function () {
           ],
         },
       ]);
-      const preloadFallbackJavaScript = assetGraph.findAssets({
-        type: 'JavaScript',
-      })[0];
-      expect(
-        preloadFallbackJavaScript.text,
-        'to contain',
-        "{'font-weight':'300 800'}"
-      );
       expect(assetGraph, 'to contain asset', {
         fileName: {
           $regex: '^Venn_VF-300_800-[a-f0-9]+.woff2',
@@ -3654,33 +3117,6 @@ describe('subsetFonts', function () {
     );
   });
 
-  // Regression test for https://github.com/Munter/subfont/issues/131
-  it('should match the right fonts up with the right paths in the JavaScript-based preload polyfill', async function () {
-    const assetGraph = new AssetGraph({
-      root: pathModule.resolve(__dirname, '../testdata/subsetFonts/issue131/'),
-    });
-    const [indexHtml, aboutHtml] = await assetGraph.loadAssets([
-      'index.html',
-      'about.html',
-    ]);
-    await assetGraph.populate({
-      followRelations: {
-        crossorigin: false,
-      },
-    });
-    await subsetFonts(assetGraph);
-    expect(
-      indexHtml.text.replace(/-[a-f0-9]{10}\./g, '-xxxxxxxxxx.'),
-      'to contain',
-      `<script>try{new FontFace('Alice__subset',"url('"+'/subfont/Alice-400-xxxxxxxxxx.woff2'.toString('url')+"') format('woff2'),url('"+'/subfont/Alice-400-xxxxxxxxxx.woff'.toString('url')+"') format('woff')",{}).load()}catch(e){}</script>`
-    );
-    expect(
-      aboutHtml.text.replace(/-[a-f0-9]{10}\./g, '-xxxxxxxxxx.'),
-      'to contain',
-      `<script>try{new FontFace('Font Awesome 5 Free__subset',"url('"+'/subfont/Font_Awesome_5_Free-400-xxxxxxxxxx.woff2'.toString('url')+"') format('woff2'),url('"+'/subfont/Font_Awesome_5_Free-400-xxxxxxxxxx.woff'.toString('url')+"') format('woff')",{}).load()}catch(e){}</script>`
-    );
-  });
-
   describe('with non-truetype fonts in the mix', function () {
     it('should not attempt to subset non-truetype fonts', async function () {
       const assetGraph = new AssetGraph({
@@ -3751,39 +3187,6 @@ describe('subsetFonts', function () {
           },
           as: 'font',
           contentType: 'font/woff2',
-        },
-        {
-          type: 'HtmlScript',
-          to: {
-            type: 'JavaScript',
-            isInline: true,
-            text: expect.it('to contain', 'icomoon__subset'),
-            outgoingRelations: [
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'rootRelative',
-                href: expect
-                  .it('to begin with', '/subfont/icomoon-400-')
-                  .and('to match', /-[0-9a-f]{10}\./)
-                  .and('to end with', '.woff2'),
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff2',
-                  extension: '.woff2',
-                },
-              },
-
-              {
-                type: 'JavaScriptStaticUrl',
-                hrefType: 'rootRelative',
-                to: {
-                  isLoaded: true,
-                  contentType: 'font/woff',
-                  extension: '.woff',
-                },
-              },
-            ],
-          },
         },
         {
           type: 'HtmlStyle',


### PR DESCRIPTION
We're at [92% global support for `<link rel="preload">`](https://caniuse.com/link-rel-preload), so I think that now's the time to part with this extra complexity.

Fixes #146