### PR TITLE
update changelog with proper version for 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v6.4.2 (2022-06-13)
+### v6.5.0 (2022-06-13)
 
 - [#161](https://github.com/Munter/subfont/pull/161) Add support for specifying additional characters to include in the subsets ([Andreas Lind](mailto:andreas.lind@workday.com), [Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 


### PR DESCRIPTION
It appears that v6.4.2 was added twice when in fact the top most instance is supposed to be v6.5.0.