### PR TITLE
perf: Fix O(n²) hot paths and add relation allowlist

### DIFF
--- a/lib/parseCommandLineOptions.js
+++ b/lib/parseCommandLineOptions.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 module.exports = function parseCommandLineOptions(argv) {
   let yargs = require('yargs');
   if (argv) {
@@ -41,9 +39,7 @@ module.exports = function parseCommandLineOptions(argv) {
       choices: ['woff2', 'woff', 'truetype'],
       coerce(formats) {
         // Make sure we support comma-separated syntax: --format truetype,woff
-        return _.flatten(
-          _.flatten([formats]).map((format) => format.split(','))
-        );
+        return [formats].flat().flatMap((format) => format.split(','));
       },
     })
     .options('text', {

--- a/lib/subfont.js
+++ b/lib/subfont.js
@@ -1,7 +1,6 @@
 const AssetGraph = require('assetgraph');
 const prettyBytes = require('pretty-bytes');
 const browsersList = require('browserslist');
-const _ = require('lodash');
 const urlTools = require('urltools');
 const util = require('util');
 const subsetFonts = require('./subsetFonts');
@@ -51,19 +50,18 @@ module.exports = async function subfont(
 
   if (!formats) {
     formats = ['woff2'];
+    const selectedSet = new Set(selectedBrowsers);
     if (
-      _.intersection(
-        browsersList('supports woff, not supports woff2'),
-        selectedBrowsers
-      ).length > 0
+      browsersList('supports woff, not supports woff2').some((b) =>
+        selectedSet.has(b)
+      )
     ) {
       formats.push('woff');
     }
     if (
-      _.intersection(
-        browsersList('supports ttf, not supports woff'),
-        selectedBrowsers
-      ).length > 0
+      browsersList('supports ttf, not supports woff').some((b) =>
+        selectedSet.has(b)
+      )
     ) {
       formats.push('truetype');
     }
@@ -117,28 +115,19 @@ module.exports = async function subfont(
     assetGraphConfig.canonicalRoot = rootUrl.replace(/\/?$/, '/'); // Ensure trailing slash
   }
 
-  const resourceHintTypes = [
-    'HtmlPreconnectLink',
-    'HtmlPrefetchLink',
-    'HtmlPreloadLink',
-    'HtmlPrerenderLink',
-    'HtmlDnsPrefetchLink',
-  ];
-
-  const anchorTypes = ['HtmlAnchor', 'SvgAnchor', 'HtmlMetaRefresh'];
-
-  const noFollowTypes = [
-    'HtmlAlternateLink',
-    'HtmlOpenGraph',
-    'RssChannelLink',
-    'JsonUrl',
-    'HtmlSearchLink',
-    'HtmlIFrameSrcDoc',
-    'HtmlIFrame',
-    'HtmlFrame',
-    'JavaScriptSourceMappingUrl',
-    'SourceMapFile',
-    'SourceMapSource',
+  // Subfont only needs to follow CSS-related relations during populate.
+  // Using an allowlist instead of a blocklist avoids loading JavaScript,
+  // images, and other assets that subfont never uses, significantly
+  // reducing populate time for sites with many pages.
+  const cssRelatedTypes = [
+    'HtmlStyle',
+    'SvgStyle',
+    'CssImport',
+    'CssFontFaceSrc',
+    'HttpRedirect', // Follow HTTP redirects so initial URLs that 301/302 still reach the HTML
+    'HtmlMetaRefresh', // Follow <meta http-equiv="refresh"> redirects
+    'HtmlConditionalComment',
+    'HtmlNoscript',
   ];
 
   let followRelationsQuery;
@@ -146,21 +135,17 @@ module.exports = async function subfont(
     followRelationsQuery = {
       $or: [
         {
-          type: {
-            $nin: [...anchorTypes, ...resourceHintTypes, ...noFollowTypes],
-          },
+          type: { $in: cssRelatedTypes },
         },
         {
-          type: { $nin: [...resourceHintTypes, ...noFollowTypes] },
+          type: { $in: [...cssRelatedTypes, 'HtmlAnchor', 'SvgAnchor'] },
           crossorigin: false,
         },
       ],
     };
   } else {
     followRelationsQuery = {
-      type: {
-        $nin: [...anchorTypes, ...resourceHintTypes, ...noFollowTypes],
-      },
+      type: { $in: cssRelatedTypes },
     };
   }
   const assetGraph = new AssetGraph(assetGraphConfig);
@@ -327,10 +312,12 @@ module.exports = async function subfont(
         maxOriginalCodePoints
       );
     }
-    const fontUsagesByFontFamily = _.groupBy(
-      fontUsages,
-      (fontUsage) => fontUsage.props['font-family']
-    );
+    const fontUsagesByFontFamily = {};
+    for (const fontUsage of fontUsages) {
+      const key = fontUsage.props['font-family'];
+      if (!fontUsagesByFontFamily[key]) fontUsagesByFontFamily[key] = [];
+      fontUsagesByFontFamily[key].push(fontUsage);
+    }
     const numFonts = Object.keys(fontUsagesByFontFamily).length;
     log(
       `${assetFileName}: ${numFonts} font${numFonts === 1 ? '' : 's'} (${
@@ -376,8 +363,8 @@ module.exports = async function subfont(
                   fontUsage.numAxesPinned > 0
                     ? ''
                     : fontUsage.numAxesReduced === 1
-                    ? ' axis'
-                    : ' axes'
+                      ? ' axis'
+                      : ' axes'
                 } reduced`
               );
             }

--- a/lib/subsetFonts.js
+++ b/lib/subsetFonts.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const memoizeSync = require('memoizesync');
 const urltools = require('urltools');
 
@@ -30,11 +29,12 @@ const getFontInfo = require('./getFontInfo');
 
 const googleFontsCssUrlRegex = /^(?:https?:)?\/\/fonts\.googleapis\.com\/css/;
 
-const initialValueByProp = _.pick(require('./initialValueByProp'), [
-  'font-style',
-  'font-weight',
-  'font-stretch',
-]);
+const allInitialValues = require('./initialValueByProp');
+const initialValueByProp = {
+  'font-style': allInitialValues['font-style'],
+  'font-weight': allInitialValues['font-weight'],
+  'font-stretch': allInitialValues['font-stretch'],
+};
 
 const contentTypeByFontFormat = {
   woff: 'font/woff', // https://tools.ietf.org/html/rfc8081#section-4.4.5
@@ -161,76 +161,84 @@ function groupTextsByFontFamilyProps(
     }
   }
 
-  snappedTexts.push(
-    ..._.flatMapDeep(globalTextByPropsArray, (textAndProps) => {
-      const isOnPage = pageTextByPropsArray.includes(textAndProps);
-      const family = textAndProps.props['font-family'];
-      if (family === undefined) {
-        return [];
+  for (const textAndProps of globalTextByPropsArray) {
+    const isOnPage = pageTextByPropsArray.includes(textAndProps);
+    const family = textAndProps.props['font-family'];
+    if (family === undefined) {
+      continue;
+    }
+    // Find all the families in the traced font-family that we have @font-face declarations for:
+    const families = cssFontParser
+      .parseFontFamily(family)
+      .filter((family) =>
+        availableFontFaceDeclarations.some(
+          (fontFace) =>
+            fontFace['font-family'].toLowerCase() === family.toLowerCase()
+        )
+      );
+
+    for (const family of families) {
+      const activeFontFaceDeclaration = fontSnapper(
+        availableFontFaceDeclarations,
+        {
+          ...textAndProps.props,
+          'font-family': stringifyFontFamily(family),
+        }
+      );
+
+      if (!activeFontFaceDeclaration) {
+        continue;
       }
-      // Find all the families in the traced font-family that we have @font-face declarations for:
-      const families = cssFontParser
-        .parseFontFamily(family)
-        .filter((family) =>
-          availableFontFaceDeclarations.some(
-            (fontFace) =>
-              fontFace['font-family'].toLowerCase() === family.toLowerCase()
-          )
-        );
 
-      return families.map((family) => {
-        const activeFontFaceDeclaration = fontSnapper(
-          availableFontFaceDeclarations,
-          {
-            ...textAndProps.props,
-            'font-family': stringifyFontFamily(family),
-          }
-        );
+      const { relations, ...props } = activeFontFaceDeclaration;
+      const fontUrl = getPreferredFontUrl(relations);
+      if (!fontUrl) {
+        continue;
+      }
 
-        if (!activeFontFaceDeclaration) {
-          return [];
-        }
+      const fontStyle = normalizeFontPropertyValue(
+        'font-style',
+        textAndProps.props['font-style']
+      );
 
-        const { relations, ...props } = activeFontFaceDeclaration;
-        const fontUrl = getPreferredFontUrl(relations);
+      let fontWeight = normalizeFontPropertyValue(
+        'font-weight',
+        textAndProps.props['font-weight']
+      );
+      if (fontWeight === 'normal') {
+        fontWeight = 400;
+      }
 
-        const fontStyle = normalizeFontPropertyValue(
-          'font-style',
-          textAndProps.props['font-style']
-        );
-
-        let fontWeight = normalizeFontPropertyValue(
-          'font-weight',
-          textAndProps.props['font-weight']
-        );
-        if (fontWeight === 'normal') {
-          fontWeight = 400;
-        }
-
-        return {
-          htmlOrSvgAsset: textAndProps.htmlOrSvgAsset,
-          text: textAndProps.text,
-          fontVariationSettings: textAndProps.props['font-variation-settings'],
-          fontStyle,
-          fontWeight,
-          fontStretch: normalizeFontPropertyValue(
-            'font-stretch',
-            textAndProps.props['font-stretch']
-          ),
-          animationTimingFunction:
-            textAndProps.props['animation-timing-function'],
-          props,
-          fontRelations: relations,
-          fontUrl,
-          preload: isOnPage,
-        };
+      snappedTexts.push({
+        htmlOrSvgAsset: textAndProps.htmlOrSvgAsset,
+        text: textAndProps.text,
+        fontVariationSettings: textAndProps.props['font-variation-settings'],
+        fontStyle,
+        fontWeight,
+        fontStretch: normalizeFontPropertyValue(
+          'font-stretch',
+          textAndProps.props['font-stretch']
+        ),
+        animationTimingFunction:
+          textAndProps.props['animation-timing-function'],
+        props,
+        fontRelations: relations,
+        fontUrl,
+        preload: isOnPage,
       });
-    }).filter((textByProps) => textByProps && textByProps.fontUrl)
-  );
+    }
+  }
 
-  const textsByFontUrl = _.groupBy(snappedTexts, 'fontUrl');
+  const textsByFontUrl = {};
+  for (const item of snappedTexts) {
+    const key = item.fontUrl;
+    if (!textsByFontUrl[key]) {
+      textsByFontUrl[key] = [];
+    }
+    textsByFontUrl[key].push(item);
+  }
 
-  return _.map(textsByFontUrl, (textsPropsArray, fontUrl) => {
+  return Object.entries(textsByFontUrl).map(([fontUrl, textsPropsArray]) => {
     const texts = textsPropsArray.map((obj) => obj.text);
     const preload = textsPropsArray.some((obj) => obj.preload);
     const fontFamilies = new Set(
@@ -409,7 +417,7 @@ async function getVariationAxisBounds(
         seenAxisValues = new Set([defaultValue]);
       }
       if (seenAxisValues && seenAxisValues.size === 1) {
-        variationAxes[axisName] = _.clamp([...seenAxisValues][0], min, max);
+        variationAxes[axisName] = Math.min(Math.max([...seenAxisValues][0], min), max);
         numAxesPinned += 1;
       } else if (seenAxisValues) {
         const minSeenValue = Math.min(...seenAxisValues);
@@ -931,7 +939,7 @@ function getVariationAxisUsage(htmlOrSvgAssetTextsWithProps) {
         noteUsedValue(
           fontUrl,
           'wght',
-          _.clamp(fontWeight, ...minMaxFontWeight)
+          Math.min(Math.max(fontWeight, minMaxFontWeight[0]), minMaxFontWeight[1])
         );
       }
 
@@ -940,7 +948,7 @@ function getVariationAxisUsage(htmlOrSvgAssetTextsWithProps) {
         noteUsedValue(
           fontUrl,
           'wdth',
-          _.clamp(fontStrech, ...minMaxFontStretch)
+          Math.min(Math.max(fontStrech, minMaxFontStretch[0]), minMaxFontStretch[1])
         );
       }
 
@@ -997,7 +1005,7 @@ async function warnAboutUnusedVariationAxes(
       let usedValues = [];
       if (seenAxisValuesByAxisName.has(name) && !outOfBoundsAxes.has(name)) {
         usedValues = [...seenAxisValuesByAxisName.get(name)].map((usedValue) =>
-          _.clamp(usedValue, min, max)
+          Math.min(Math.max(usedValue, min), max)
         );
       }
       if (!usedValues.every((value) => value === defaultValue)) {
@@ -1961,7 +1969,7 @@ async function subsetFonts(
     fontInfo: htmlOrSvgAssetTextsWithProps.map(
       ({ fontUsages, htmlOrSvgAsset }) => ({
         assetFileName: htmlOrSvgAsset.nonInlineAncestor.urlOrDescription,
-        fontUsages: fontUsages.map((fontUsage) => _.omit(fontUsage, 'subsets')),
+        fontUsages: fontUsages.map(({ subsets, ...rest }) => rest),
       })
     ),
   };


### PR DESCRIPTION
I use `subfont` for my website, [`turntrout.com`](https://turntrout.com/design#fonts). I have over 140 pages, and the subset script began taking over two hours (up from half an hour). I figured something was causing bad complexity. With the help of AI, I refactored the codebase and it now works much faster (down below 20 minutes or so). Eventually I ended up refactoring and modernizing most of the codebase. I've split this up into a range of PRs. This first one is focused on performance.


-----

The `groupTextsByFontFamilyProps` inner loop used `_.flatMapDeep` + `.filter`, allocating intermediate arrays on every iteration. Replace with `for-of` +`continue`. Replace `_.intersection` (O(n·m)) with a `Set` lookup (O(n)). Replace remaining lodash calls with native equivalents throughout.

Switch relation-following from a blocklist of 16 types to an allowlist of 8 CSS-related types, so `populate()` skips JavaScript, images, iframes, and source maps entirely. This is the main bottleneck on multi-page sites.